### PR TITLE
ScopeExit.disposer returns itself.

### DIFF
--- a/src/utils/scope-exit.ts
+++ b/src/utils/scope-exit.ts
@@ -22,8 +22,8 @@ export class ScopeExit {
     return this;
   }
 
-  disposer(): Promise.Disposer<any> {
-    return Promise.resolve().disposer(async (result, promise) => {
+  disposer(): Promise.Disposer<ScopeExit> {
+    return Promise.resolve(this).disposer(async (result, promise) => {
       let tasks: DeferredTask[];
       if (promise.isFulfilled()) {
         tasks = this.tasksOnFulfilled;


### PR DESCRIPTION
To support following usage.
```
Promise.using<ScopeExit, void>(new scopeExit().disposer(), async(scopeExit) => {
  // do something
  return;
});
```