### PR TITLE
WIP: Improved RPC invoking

### DIFF
--- a/src/services/rpc-service.ts
+++ b/src/services/rpc-service.ts
@@ -118,6 +118,10 @@ function enterScope(properties: any, func): Promise<any> {
   });
 }
 
+export class ExternalRpc {
+  test() { throw new LogicError(ISLAND.LOGIC.L0007_NOT_IMPLEMENTED) }
+}
+
 export default class RPCService {
   private consumerInfosMap: { [name: string]: IConsumerInfo } = {};
   private responseQueue: string;
@@ -126,9 +130,12 @@ export default class RPCService {
   private reqTimeouts: {[corrId: string]: any} = {};
   private channelPool: AmqpChannelPoolService;
   private serviceName: string;
+  
+  externalRpc: ExternalRpc;
 
   constructor(serviceName?: string) {
     this.serviceName = serviceName || 'unknown';
+    this.externalRpc = new ExternalRpc();
   }
 
   public async initialize(channelPool: AmqpChannelPoolService): Promise<any> {

--- a/src/spec/improved-rpc.spec.ts
+++ b/src/spec/improved-rpc.spec.ts
@@ -1,0 +1,24 @@
+require('source-map-support').install();
+import RPCService from '../services/rpc-service';
+import { ISLAND, LogicError } from '../utils/error';
+
+import { ExternalRpc } from '../services/rpc-service';
+declare module '../services/rpc-service' {
+  interface ExternalRpc {
+    getString(o: string): string;
+  }
+}
+
+ExternalRpc.prototype.getString = (o: string) => o;
+
+describe('Improved RPC', () => {
+  const rpcService = new RPCService('haha');
+  
+  it('should have test a RPC', () => {
+    expect(() => rpcService.externalRpc.test()).toThrow(new LogicError(ISLAND.LOGIC.L0007_NOT_IMPLEMENTED));
+  });
+  
+  it('should be augmented', () => {
+    expect(rpcService.externalRpc.getString('haha')).toBe('haha');
+  });
+});

--- a/src/utils/error.ts
+++ b/src/utils/error.ts
@@ -54,12 +54,13 @@ export class FatalError extends AbstractFatalError {
 
 export namespace ISLAND {
   export enum LOGIC {
-    L0001_PLAYER_NOT_EXIST = 1,
-    L0002_WRONG_PARAMETER_SCHEMA = 2,
-    L0003_NOT_INITIALIZED_EXCEPTION = 3,
-    L0004_MSG_PACK_ERROR = 4,
-    L0005_MSG_PACK_ENCODE_ERROR = 5,
-    L0006_HANDLE_MESSAGE_ERROR = 6,
+    L0001_PLAYER_NOT_EXIST            = 1,
+    L0002_WRONG_PARAMETER_SCHEMA      = 2,
+    L0003_NOT_INITIALIZED_EXCEPTION   = 3,
+    L0004_MSG_PACK_ERROR              = 4,
+    L0005_MSG_PACK_ENCODE_ERROR       = 5,
+    L0006_HANDLE_MESSAGE_ERROR        = 6,
+    L0007_NOT_IMPLEMENTED             = 7,
   }
 
   export enum FATAL {


### PR DESCRIPTION
# Proposal

reference #3 
## Type Merging

RPC invoking could be more transparent with `Module Augmentation` above TS 1.8.
### AS-IS

``` typescript
async a(param): ReturnType {
  return await rpcService.invoke<ParamType, ReturnType>('zzz', param);
}
```
### TO-BE

``` typescript
async a(param): ReturnType {
  return await rpcService.zzz(param);
}
```
### Module Augmentation

``` typescript
// src/services/rpc-service.ts@island
export class ExternalRpc {
  someDefaultRpc(o: string): Promise<string> {
    return Promise.resolve(o);
  }
}

export class RPCService {
  externalRpc: ExternalRpc;
  constructor () {
    externalRpc = new ExternalRpc;
  }
}

// src/test.ts@sample-island
import { ExternalRpc } from 'island/dist/services/rpc-service'; // <- little bit tricky, but needed
module 'island/dist/services/rpc-service' {
  interface ExternalRpc {
    getString(o: string): Promise<string>;
  }
}

let externalRpc: ExternalRpc;
externalRpc.getString('hello').then(o => console.log(o));
```
## Auto generating implementation

Type merging was an easy part.
(continue...)
