### PR TITLE
add condition on island.spyAll

### DIFF
--- a/src/utils/jasmine-async-support.ts
+++ b/src/utils/jasmine-async-support.ts
@@ -20,6 +20,10 @@ export function jasmineAsyncAdapter(assertion: () => Promise<void>) {
 export function createSpyObjWithAllMethods<T>(Class: new (...args) => T): T {
   const methods = Object.getOwnPropertyNames(Class.prototype)
     .filter(name => name !== 'constructor');
+  
+  if (!methods || methods.length === 0) {
+    return {} as T;
+  }
 
   return jasmine.createSpyObj(Class.name, methods);
 }


### PR DESCRIPTION
- island.spyAll 시 함수가 등록되지 않은 클래스를 넣으면 throw가 발생한다
- 개발 단계에서는 비어있는 클래스가 있을 수 있기 때문에 조건문 추가