### PR TITLE
Exit process if initialization failed

### DIFF
--- a/src/islet.ts
+++ b/src/islet.ts
@@ -94,7 +94,11 @@ export default class Islet {
           .then(() => Promise.all(adapters.map(adapter => adapter.listen())));
       })
       .then(() => logger.info('started'))
-      .then(() => this.onStarted());
+      .then(() => this.onStarted())
+      .catch(e => {
+        console.log('failed to initialize', e);
+        process.exit(1);
+      });
   }
 
   protected onInitialized() {}


### PR DESCRIPTION
The island do not handle rejected promise on initialization process. Node's behavior for unhandled rejected promise is DO NOTHING and Bluebird just shows warnings.
So even if island fails to connect to backend middlewares like redis, currently, island just shows warnings and process stays alive.
We prefer a process termination and restarting automatically rather than staying.

Other islands are restarted in this case. TC finds only common islands work differently and claims to be fixed.