### PR TITLE
Log event error / Set prefetch count / Trigger auto-delete / Fix AmqpChannelPool

### DIFF
--- a/src/services/rpc-service.ts
+++ b/src/services/rpc-service.ts
@@ -172,6 +172,7 @@ export default class RPCService {
   protected async _consume(key: string, handler: (msg) => Promise<any>, tag: string, options?: any):
       Promise<IConsumerInfo> {
     const channel = await this.channelPool.acquireChannel();
+    await channel.prefetch(+process.env.RPC_PREFETCH || 1000);
     const result = await channel.consume(key, async (msg) => {
       try {
         await handler(msg);


### PR DESCRIPTION
This pull request contains below various revisions.
- Publish log.eventError when error occured while handling event.
- Set prefetch count for event and rpc consumers
- Bind and unbind exchange immediately when bind fails for preventing auto-delete not triggered.
- Fix AmqpChannelPool to remove timing issues.
