### PR TITLE
Avoiding 404 channel error on pushService.unicast

### DIFF
--- a/src/services/push-service.ts
+++ b/src/services/push-service.ts
@@ -1,13 +1,6 @@
-'use strict';
-
-import * as amqp from 'amqplib';
-import * as Promise from 'bluebird';
 import MessagePack from '../utils/msgpack';
 import { AmqpChannelPoolService } from './amqp-channel-pool-service';
-import _debug = require('debug');
-import * as _ from 'lodash';
-
-let debug = _debug('ISLAND:SERVICES:PUSH');
+import { logger } from '../utils/logger';
 
 export default class PushService {
   private static DEFAULT_EXCHANGE_OPTIONS: any = {
@@ -15,21 +8,31 @@ export default class PushService {
     autoDelete: true
   };
 
+  private static autoDeleteTriggerQueue = {
+    name: 'auto-delete.trigger',
+    options: {
+      messageTtl: 0
+    }
+  };
+
   private msgpack: MessagePack;
   private channelPool: AmqpChannelPoolService;
 
-  // this exchange is used for braodcasting
-  public static globalFanoutExchange = {
+  // Exchange to broadcast to the entire users.
+  public static broadcastExchange = {
     name: 'PUSH_FANOUT_EXCHANGE',
-    option: {
+    type: 'fanout',
+    options: {
       durable: true
     }
   };
 
-  public static autoDeleteTriggerQueue = {
-    name: 'auto-delete.trigger',
+  // Exchange to push to a specific user.
+  public static playerPushExchange = {
+    name: 'push.player',
+    type: 'direct',
     options: {
-      messageTtl: 0
+      durable: true
     }
   };
 
@@ -41,33 +44,29 @@ export default class PushService {
     this.channelPool = channelPool;
 
     await this.channelPool.usingChannel(async (channel) => {
-      await channel.assertExchange(PushService.globalFanoutExchange.name, 'fanout',
-        PushService.globalFanoutExchange.option);
+      const globalFanoutX = PushService.broadcastExchange;
+      const playerPushX = PushService.playerPushExchange;
+      await channel.assertExchange(globalFanoutX.name, globalFanoutX.type, globalFanoutX.options);
+      await channel.assertExchange(playerPushX.name, playerPushX.type, playerPushX.options);
       await channel.assertQueue(PushService.autoDeleteTriggerQueue.name, PushService.autoDeleteTriggerQueue.options);
     });
   }
 
-  purge() {
+  async purge(): Promise<any> {
     return this.channelPool.usingChannel(channel => {
-      return channel.deleteExchange(PushService.globalFanoutExchange.name, {ifUnused: true});
+      return channel.deleteExchange(PushService.broadcastExchange.name, {ifUnused: true});
     });
   }
 
-  deleteExchange(exchange:string, options?: any) {
+  async deleteExchange(exchange:string, options?: any): Promise<any> {
     return this.channelPool.usingChannel(channel => {
-      return this._deleteExchange(channel, [exchange], options);
+      logger.debug(`[INFO] delete exchange's name ${exchange}`);
+      return channel.deleteExchange(exchange, options);
     });
-  }
-
-  private _deleteExchange(channel: amqp.Channel, exchanges: string[], options) {
-    return Promise.reduce(exchanges, (total, exchange) => {
-      debug(`[INFO] delete exchange's name ${exchange}`)
-      return Promise.resolve(channel.deleteExchange(exchange, options));
-    }, 0);
   }
 
   /**
-   * bind specific exchange to (Account|Player) exchange
+   * bind specific exchange wrapper
    * @param destination
    * @param source
    * @param pattern
@@ -81,8 +80,7 @@ export default class PushService {
                      sourceType: string = 'fanout',
                      sourceOpts: any = PushService.DEFAULT_EXCHANGE_OPTIONS
   ): Promise<any> {
-    debug(`bind exchanges. (source:${source}) => destination:${destination}`);
-
+    logger.debug(`bind exchange. ${source} ==${pattern}==> ${destination}`);
     let sourceDeclared = false;
     try {
       await this.channelPool.usingChannel(async (channel) => {
@@ -107,42 +105,43 @@ export default class PushService {
   }
 
   /**
-   * unbind specfic exchange from (Account|Player) exchange
+   * unbind exchange wrapper
    * @param destination
    * @param source
    * @param pattern
    * @returns {Promise<any>}
    */
-  unbindExchange(destination: string, source: string, pattern?: string) {
+  async unbindExchange(destination: string, source: string, pattern: string = ''): Promise<any> {
+    logger.debug(`unbind exchange; ${source} --${pattern}--X ${destination}`);
     return this.channelPool.usingChannel(channel => {
-      return channel.unbindExchange(destination, source, pattern || '', {});
+      return channel.unbindExchange(destination, source, pattern, {});
     });
   }
 
   /**
-   * publish message to (Account|Player) exchange
-   * @param exchange
+   * publish message to a player
+   * @param pid
    * @param msg
    * @param options
    * @returns {Promise<any>}
    */
-  unicast(exchange: string, msg: any, options?: any) {
-    return this.channelPool.usingChannel(channel => {
-      return Promise.resolve(channel.publish(exchange, '', this.msgpack.encode(msg), options));
+  async unicast(pid: string, msg: any, options?: any): Promise<any> {
+    return this.channelPool.usingChannel(async (channel) => {
+      return channel.publish(PushService.playerPushExchange.name, pid, this.msgpack.encode(msg), options);
     });
   }
 
   /**
-   * publish message to specific exchange bound to (Account|Player) exchange
+   * publish message to specific exchange
    * @param exchange
    * @param msg
    * @param routingKey
    * @param options
    * @returns {Promise<any>}
    */
-  multicast(exchange: string, msg: any, routingKey?: string, options?: any) {
-    return this.channelPool.usingChannel(channel => {
-      return Promise.resolve(channel.publish(exchange, routingKey || '', this.msgpack.encode(msg), options));
+  async multicast(exchange: string, msg: any, routingKey: string = '', options?: any): Promise<any> {
+    return this.channelPool.usingChannel(async (channel) => {
+      return channel.publish(exchange, routingKey, this.msgpack.encode(msg), options);
     });
   }
 
@@ -152,10 +151,10 @@ export default class PushService {
    * @param options publish options
    * @returns {Promise<any>}
    */
-  broadcast(msg: any, options?: any) {
-    return this.channelPool.usingChannel(channel => {
-      const fanout = PushService.globalFanoutExchange.name;
-      return Promise.resolve(channel.publish(fanout, '', this.msgpack.encode(msg), options));
+  async broadcast(msg: any, options?: any): Promise<any> {
+    return this.channelPool.usingChannel(async (channel) => {
+      const fanout = PushService.broadcastExchange.name;
+      return channel.publish(fanout, '', this.msgpack.encode(msg), options);
     });
   }
 }

--- a/src/utils/resource-push.ts
+++ b/src/utils/resource-push.ts
@@ -77,7 +77,7 @@ export class ResourceTarget extends ResourcePath {
     super('', []);
   }
 
-  flush(): Promise<any> {
+  async flush(): Promise<any> {
     return this.pushService.unicast(this.target, {cmd: 'resources', opts: this.changes});
   }
 }


### PR DESCRIPTION
Publishing to player exchange frequently causes amqp channel error (404 not found), and it abruptly  closes current channel.
As a workaround, Push-island declares direct exchange 'push.player' and bind it to player exchange using pid as routing-key. We can always publish a message through this permanent exchange without any care.
