### PR TITLE
Add support to expand langid from property name for @validate @sanitize

### DIFF
--- a/src/controllers/endpoint-decorator.ts
+++ b/src/controllers/endpoint-decorator.ts
@@ -52,6 +52,7 @@ type SchemaInspectorProperty = {
   type?: 'string' | 'number' | 'integer' | 'boolean' | 'null' | 'date' | 'object' | 'array' | 'any' | '$oid' | '$cider' | '$numberOrQuery';
   properties?: any;
   items?: any | [any];
+  __langid?: string;
 }
 
 
@@ -239,6 +240,11 @@ export namespace sanitize {
       } else if (key.endsWith('!')) {
         property.optional = false;
         key = key.slice(0, -1);
+      }
+      if (key.includes('+')) {
+        const [a] = key.split('+', 1);
+        property.__langid = key;
+        key = a;
       }
       properties[key] = parseSanitization(property, value);
     });
@@ -467,6 +473,11 @@ export namespace validate {
       } else if (key.endsWith('!')) {
         property.optional = false;
         key = key.slice(0, -1);
+      }
+      if (key.includes('+')) {
+        const [a] = key.split('+', 1);
+        property.__langid = key;
+        key = a;
       }
       properties[key] = parseValidation(property, value);
     });

--- a/src/spec/schema-decorator.spec.ts
+++ b/src/spec/schema-decorator.spec.ts
@@ -338,3 +338,32 @@ describe('sanitize', () => {
     }});
   });
 });
+
+describe('__langid', () => {
+  it('should be copied on sanitization', () => {
+    const result = island.sanitize.sanitize({
+      'id+uniqueid': String,
+      'roomid+very+good+room!': island.sanitize.ObjectId
+    });
+    expect(result).toEqual({
+      type: 'object',
+      properties: {
+        'id': {type: 'string', optional: true, __langid: 'id+uniqueid'},
+        'roomid': {type: '$oid', optional: false, __langid: 'roomid+very+good+room'}
+      }
+    });
+  });
+  it('should be copied on validation', () => {
+    const result = island.validate.validate({
+      'id+uniqueid?': String,
+      'roomid+very+good+room': island.validate.ObjectId
+    });
+    expect(result).toEqual({
+      type: 'object',
+      properties: {
+        'id': {type: 'string', optional: true, __langid: 'id+uniqueid'},
+        'roomid': {type: '$oid', optional: false, __langid: 'roomid+very+good+room'}
+      }
+    });
+  });
+});


### PR DESCRIPTION
```typescript
 @sanitize.query({
    'id+maxPlayer': sanitize.ObjectId,
    clientid: String,
    'offset!': 0,
    'limit!': 30
  })
```

should be translated like

```typescript
{
  id: {
    type: '$oid',
    __langid: 'id+maxPlayer',
  },
  clientid: { type: 'string' },
  offset: { type: 'number', def: 0, optional: false },
  limit: { type: 'number', def: 30, optional: false }
}
```