### PR TITLE
Fix possible missing a RPC response

### DIFF
--- a/src/services/rpc-service.ts
+++ b/src/services/rpc-service.ts
@@ -354,14 +354,15 @@ export default class RPCService {
       replyTo: this.responseQueue,
       expiration: `${RPC_WAIT_TIMEOUT_MS}` // [FIXME] https://github.com/louy/typed-amqplib/pull/1
     };
+    const p = this.markTattoo(name, correlationId, tattoo, ns, opts)
+      .catch((err) => {
+        err.tattoo = tattoo;
+        throw err;
+      });
     await this.channelPool.usingChannel(channel => {
       return Promise.resolve(channel.sendToQueue(name, content, options));
     });
-    return await this.markTattoo(name, correlationId, tattoo, ns, opts)
-    .catch((err) => {
-      err.tattoo = tattoo;
-      throw err;
-    })
+    return await p;
   }
 
   private markTattoo(name: string, corrId: any, tattoo: any, ns: any, opts: any): Promise<any> {

--- a/src/services/rpc-service.ts
+++ b/src/services/rpc-service.ts
@@ -359,9 +359,17 @@ export default class RPCService {
         err.tattoo = tattoo;
         throw err;
       });
-    await this.channelPool.usingChannel(channel => {
-      return Promise.resolve(channel.sendToQueue(name, content, options));
-    });
+
+    try {
+      await this.channelPool.usingChannel(channel => {
+        return Promise.resolve(channel.sendToQueue(name, content, options));
+      });
+    } catch (e) {
+      clearTimeout(this.reqTimeouts[correlationId]);
+      delete this.reqTimeouts[correlationId];
+      delete this.reqExecutors[correlationId];
+      throw e;
+    }
     return await p;
   }
 


### PR DESCRIPTION
Sometimes we got a message like

> [RPC-WARNING] invalid correlationId 450a7641-f692-4057-865f-8d87a6ce253b

or 

> (node:25) UnhandledPromiseRejectionWarning: Unhandled promise rejection (rejection id: 2): FatalError: code: ISLAND.FATAL.F0023_RPC_TIMEOUT, msg: RPC(testIng does not return in 60000 ms'

It is followed by 60s timeout for waiting a RPC response. But there is a chance that miss a RPC response despite another island already respond.
