### PR TITLE
Change error logging event / Add ExpectedError

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -90,7 +90,13 @@ export {
   createSpyObjWithAllMethods as spyAll,
   resetSpyObjWithCallsCount as resetCallsCount
 } from './utils/jasmine-async-support';
-export { ErrorType, AbstractError, AbstractFatalError, AbstractLogicError } from './utils/error';
+export {
+  ErrorType,
+  AbstractError,
+  AbstractExpectedError,
+  AbstractFatalError,
+  AbstractLogicError
+} from './utils/error';
 export { Events } from './utils/event';
 
 export { Di, ObjectWrapper, ObjectFactory } from 'island-di';

--- a/src/services/event-service.ts
+++ b/src/services/event-service.ts
@@ -84,10 +84,10 @@ export class EventService {
   }
 
   private async sendErrorLog(err: Error, msg: Message): Promise<any> {
+    logger.error(`error on handling event`, err);
     if ('ExpectedError' === err.name) return;
     if ('log.error' === msg.fields.routingKey) return; // preventing loop
 
-    logger.error(`error on handling event`, err);
     const errorLog = {
       message: err.message,
       stack: err.stack,

--- a/src/services/event-service.ts
+++ b/src/services/event-service.ts
@@ -3,11 +3,17 @@ import * as _ from 'lodash';
 import * as Bluebird from 'bluebird';
 import * as amqp from 'amqplib';
 import * as uuid from 'uuid';
-
 import { Events } from '../utils/event';
 import { AmqpChannelPoolService } from './amqp-channel-pool-service';
-import { Message, Event, EventHandler, Subscriber, EventSubscriber, PatternSubscriber } from './event-subscriber';
-
+import {
+  Message,
+  Event,
+  EventHandler,
+  Subscriber,
+  EventSubscriber,
+  PatternSubscriber,
+  BaseEvent
+} from './event-subscriber';
 import { TraceLog } from '../utils/tracelog';
 import { logger } from '../utils/logger';
 import reviver from '../utils/reviver';
@@ -67,20 +73,7 @@ export class EventService {
           return;
         }
         Bluebird.resolve(this.handleMessage(msg))
-          .catch(e => {
-            logger.error(`error on handling event`, e);
-            let params = msg.content;
-            try {
-              params = JSON.parse(msg.content.toString('utf8'), reviver);
-            } catch (e) {
-            }
-            const buffer = new Buffer(JSON.stringify({
-              event: msg.fields.routingKey,
-              params: params,
-              error: e
-            }), 'utf8');
-            return this._publish(EventService.EXCHANGE_NAME, 'log.eventError', buffer, {});
-          })
+          .catch(e => this.sendErrorLog(e, msg))
           .finally(() => {
             channel.ack(msg);
             //todo: fix me. we're doing ACK always even if promise rejected.
@@ -88,6 +81,28 @@ export class EventService {
           });
     }));
     // TODO: save channel and consumer tag
+  }
+
+  private async sendErrorLog(err: Error, msg: Message): Promise<any> {
+    if ('ExpectedError' === err.name) return;
+    if ('log.error' === msg.fields.routingKey) return; // preventing loop
+
+    logger.error(`error on handling event`, err);
+    const errorLog = {
+      message: err.message,
+      stack: err.stack,
+      params: (() => {
+        try {
+          return JSON.parse(msg.content.toString('utf8'), reviver);
+        } catch (e) {
+          return msg.content;
+        }
+      })()
+    };
+    for (const field in err) {
+      errorLog[field] = err[field];
+    }
+    return this.publishEvent(new BaseEvent('log.error', errorLog));
   }
 
   private handleMessage(msg: Message): Promise<any> {

--- a/src/services/event-service.ts
+++ b/src/services/event-service.ts
@@ -99,9 +99,7 @@ export class EventService {
         }
       })()
     };
-    for (const field in err) {
-      errorLog[field] = err[field];
-    }
+    _.assign(errorLog, err);
     return this.publishEvent(new BaseEvent('log.error', errorLog));
   }
 

--- a/src/utils/error.ts
+++ b/src/utils/error.ts
@@ -1,4 +1,4 @@
-export type ErrorType = 'LOGIC' | 'FATAL' | 'ETC';
+export type ErrorType = 'EXPECTED' | 'LOGIC' | 'FATAL' | 'ETC';
 
 export class AbstractError extends Error {
   public statusCode: number;
@@ -22,6 +22,16 @@ export class AbstractError extends Error {
     this.errorCode = `${islandName}.${errorType}.${enumObj[errorNumber]}`;
     this.reason = debugMsg;
     this.result = false;
+  }
+}
+
+export class AbstractExpectedError extends AbstractError {
+  constructor(errorNumber: number,
+              debugMsg: string,
+              islandName: string,
+              enumObj: any) {
+    super('EXPECTED', errorNumber, debugMsg || '', islandName, enumObj);
+    this.name = 'ExpectedError';
   }
 }
 


### PR DESCRIPTION
EventService publishes log.error event when event handlers throw error.
Already it sends 'log.eventError' but that doesn't have enough context so it needs to be revised.

Added AbstractExpectedError class.
This is for the trivial errors which we expect to be occurred in normal scenario and don't need to be logged.