### PR TITLE
Merge `Rpc.queue.expire.setting` into `master`

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ $ RABBITMQ_HOST=localhost npm test
 | `HOSTNAME`                   | TraceLog uses this as a name of node                              |
 | `ISLAND_RPC_EXEC_TIMEOUT_MS` | Timeout during execution (Defaults to 25000)                      |
 | `ISLAND_RPC_WAIT_TIMEOUT_MS` | Timeout during call (Defaults to 60000)                           |
+| `ISLAND_SERVICE_LOAD_TIME_MS`| Time to load service (Defaults to 60000)                          |
 | `ISLAND_LOGGER_LEVEL`        | Logger level of category `island`                                 |
 | `ISLAND_TRACEMQ_HOST`        | MQ(formatted by amqp URI) for TraceLog. If omitted it doesn't log |
 | `ISLAND_TRACEMQ_QUEUE`       | A queue name to log TraceLog                                      |

--- a/src/services/rpc-service.ts
+++ b/src/services/rpc-service.ts
@@ -16,6 +16,8 @@ import { AmqpChannelPoolService } from './amqp-channel-pool-service';
 
 const RPC_EXEC_TIMEOUT_MS = parseInt(process.env.ISLAND_RPC_EXEC_TIMEOUT_MS, 10) || 25000;
 const RPC_WAIT_TIMEOUT_MS = parseInt(process.env.ISLAND_RPC_WAIT_TIMEOUT_MS, 10) || 60000;
+const SERVICE_LOAD_TIME_MS = parseInt(process.env.ISLAND_SERVICE_LOAD_TIME_MS, 10) || 60000;
+const RPC_QUEUE_EXPIRES_MS = RPC_WAIT_TIMEOUT_MS + SERVICE_LOAD_TIME_MS;
 
 export interface IConsumerInfo {
   channel: amqp.Channel;
@@ -285,7 +287,10 @@ export default class RPCService {
 
     // NOTE: 컨슈머가 0개 이상에서 0개가 될 때 자동으로 삭제된다.
     // 단 한번도 컨슈머가 등록되지 않는다면 영원히 삭제되지 않는데 그런 케이스는 없음
-    await this.channelPool.usingChannel(channel => channel.assertQueue(name, { durable: false, autoDelete: true }));
+    await this.channelPool.usingChannel(channel => channel.assertQueue(name, {
+                arguments : {'x-expires': RPC_QUEUE_EXPIRES_MS},
+                durable   : false
+    }));
     this.consumerInfosMap[name] = await this._consume(name, consumer, 'SomeoneCallsMe');
   }
 

--- a/src/spec/rpc-spec.ts
+++ b/src/spec/rpc-spec.ts
@@ -116,12 +116,11 @@ describe('RPC test:', () => {
         result: { sanitization, validation }
       }
     };
-
-    return rpcService.register('testMethod', msg => {
+    return rpcService.register('testMethod2', msg => {
       expect(msg).toBe('hello');
       return Promise.resolve('world');
     }, 'rpc', rpcoptions).then(() => {
-      return rpcService.invoke<string, string>('testMethod', 'hello').then(res => {
+      return rpcService.invoke<string, string>('testMethod2', 'hello').then(res => {
         expect(res).toBe('world');
         done();
       });

--- a/src/spec/rpc-spec.ts
+++ b/src/spec/rpc-spec.ts
@@ -118,11 +118,11 @@ describe('RPC test:', () => {
         result: { sanitization, validation }
       }
     };
-    return rpcService.register('testMethod2', msg => {
+    return rpcService.register('testSchemaMethod', msg => {
       expect(msg).toBe('hello');
       return Promise.resolve('world');
     }, 'rpc', rpcoptions).then(() => {
-      return rpcService.invoke<string, string>('testMethod2', 'hello').then(res => {
+      return rpcService.invoke<string, string>('testSchemaMethod', 'hello').then(res => {
         expect(res).toBe('world');
         done();
       });


### PR DESCRIPTION
When the consumer disappears (the queues disappear immediately), all incoming requests timeout occur while the service is restarted.
keeping a constant time queue so that requests are not lost during restart the service