### PR TITLE
fix: incorrect delivery of error occuerred on rpc

### DIFF
--- a/src/services/rpc-service.ts
+++ b/src/services/rpc-service.ts
@@ -67,7 +67,7 @@ class RpcResponse {
           extra: e.extra,
           message: e.message,
           name: e.name,
-          occurredIn: serviceName,
+          occurredIn: e.occurredIn || serviceName,
           stack: e.stack,
           statusCode: e.statusCode
         };
@@ -89,19 +89,20 @@ class RpcResponse {
     }
   }
 
-  static getAbstractError(err: AbstractError): AbstractError {
+ static getAbstractError(err: AbstractError): AbstractError {
     let result: AbstractError;
     const enumObj = {};
     enumObj[err.errorNumber] = err.errorKey;
+    const occurredIn = err.extra && err.extra.island || err.occurredIn;
     switch (err.errorType) {
       case 'LOGIC':
-        result = new AbstractLogicError(err.errorNumber, err.debugMsg, err.occurredIn, enumObj);
+        result = new AbstractLogicError(err.errorNumber, err.debugMsg, occurredIn, enumObj);
         break;
       case 'FATAL':
-        result = new AbstractFatalError(err.errorNumber, err.debugMsg, err.occurredIn, enumObj);
+        result = new AbstractFatalError(err.errorNumber, err.debugMsg, occurredIn, enumObj);
         break;
       default:
-        result = new AbstractError('ETC', 1, err.message, err.occurredIn, { 1: 'F0001' });
+        result = new AbstractError('ETC', 1, err.message, occurredIn, { 1: 'F0001' });
         result.name = 'ETCError';
     }
 

--- a/src/spec/rpc-spec.ts
+++ b/src/spec/rpc-spec.ts
@@ -171,6 +171,64 @@ describe('RPC test:', () => {
     const res = await p;
     expect(res).toBe('hello world');
   }));
+
+  it('should know where the rpc error occurred', spec(async () => {
+    const rpcServiceSecond = new RPCService('second');
+    await rpcServiceSecond.initialize(amqpChannelPool);
+    const rpcServiceThird = new RPCService('third');
+    await rpcServiceThird.initialize(amqpChannelPool);
+
+    await rpcServiceThird.register('third', msg => {
+      throw new Error('custom error');
+    }, 'rpc');
+    await rpcServiceSecond.register('second', async msg => {
+      await rpcServiceSecond.invoke<string, string>('third', 'hello');
+    }, 'rpc');
+    await rpcService.register('first', async msg => {
+      await rpcService.invoke<string, string>('second', 'hello');
+    }, 'rpc');
+    try {
+      await rpcServiceSecond.invoke<string, string>('first', 'hello');
+    } catch (e) {
+      await rpcServiceSecond.unregister('second');
+      await rpcServiceThird.unregister('third');
+      expect(e.errorCode).toBe('third.ETC.F0001');
+    }
+  }));
+
+  it('should confirm error occurred', spec(async () => {
+    const rpcServiceSecond = new RPCService('second');
+    await rpcServiceSecond.initialize(amqpChannelPool);
+    const rpcServiceThird = new RPCService('third');
+    await rpcServiceThird.initialize(amqpChannelPool);
+    const validation = { type: 'string' };
+    const rpcOptions: RpcOptions = {
+      schema: {
+        query: { sanitization: {}, validation },
+        result: { sanitization: {}, validation }
+      }
+    };
+
+    await rpcServiceThird.register('third', msg => Promise.resolve('hello'), 'rpc', rpcOptions);
+
+    await rpcServiceSecond.register('second', msg => {
+      return rpcServiceSecond.invoke<any, string>('third', 1234);
+    }, 'rpc');
+
+    await rpcService.register('first', msg => {
+      return rpcService.invoke<string, string>('second', 'hello');
+    }, 'rpc');
+
+    try {
+      const p = await rpcServiceSecond.invoke<string, string>('first', 'hello');
+      console.log(p);
+    } catch (e) {
+      await rpcServiceSecond.unregister('second');
+      await rpcServiceThird.unregister('third');
+      expect(e.errorCode).toBe('ISLAND.LOGIC.L0002_WRONG_PARAMETER_SCHEMA');
+      expect(e.occurredIn).toBe('third');
+    }
+  }));
 });
 
 describe('RPC with reviver', async () => {

--- a/src/utils/error.ts
+++ b/src/utils/error.ts
@@ -22,6 +22,7 @@ export class AbstractError extends Error {
     this.errorCode = `${islandName}.${errorType}.${enumObj[errorNumber]}`;
     this.reason = debugMsg;
     this.result = false;
+    this.extra = this.extra || { island: islandName };
   }
 }
 


### PR DESCRIPTION
fixed the above content
- In the case of an error that has passed through multiple ISLAND, the point of 'occurred error' does not appear correctly.
- the error message is not correct.
fixed wrong error message like 'DUMMY.LOGIC.L0002_WRONG_PARAMETER_SCHEMA' to correctly 'ISLAND.LOGIC.L0002_WRONG_PARAMETER_SCHEMA'