### PR TITLE
Fix.prefetch.count.modify

### DIFF
--- a/src/services/amqp-channel-pool-service.ts
+++ b/src/services/amqp-channel-pool-service.ts
@@ -8,8 +8,9 @@ import { logger } from '../utils/logger';
 export interface AmqpOptions {
   url: string;
   socketOptions?: { noDelay?: boolean, heartbeat?: number };
-  poolSize?: number ;
+  poolSize?: number;
   name?: string;
+  prefetchCount?: number;
 }
 
 export interface ChannelInfo {
@@ -43,6 +44,10 @@ export class AmqpChannelPoolService {
     } catch (e) { this.initResolver.reject(e); }
 
     return Promise.resolve(this.initResolver.promise);
+  }
+
+  getPrefetchCount(): (number | undefined) {
+    return this.options.prefetchCount;
   }
 
   async waitForInit(): Promise<void> {

--- a/src/services/event-service.ts
+++ b/src/services/event-service.ts
@@ -141,7 +141,7 @@ export class EventService {
 
   private registerConsumer(channel: amqp.Channel, queue: string): Promise<any> {
     const prefetchCount = this.channelPool.getPrefetchCount();
-    return Promise.resolve(prefetchCount || channel.prefetch(+process.env.EVENT_PREFETCH || 1000))
+    return Promise.resolve(channel.prefetch(prefetchCount || +process.env.EVENT_PREFETCH || 1000))
       .then(() => channel.consume(queue, msg => {
         if (!msg) {
           logger.error(`consume was canceled unexpectedly`);

--- a/src/services/event-service.ts
+++ b/src/services/event-service.ts
@@ -140,7 +140,8 @@ export class EventService {
   }
 
   private registerConsumer(channel: amqp.Channel, queue: string): Promise<any> {
-    return Promise.resolve(channel.prefetch(+process.env.EVENT_PREFETCH || 1000))
+    const prefetchCount = this.channelPool.getPrefetchCount();
+    return Promise.resolve(prefetchCount || channel.prefetch(+process.env.EVENT_PREFETCH || 1000))
       .then(() => channel.consume(queue, msg => {
         if (!msg) {
           logger.error(`consume was canceled unexpectedly`);

--- a/src/services/rpc-service.ts
+++ b/src/services/rpc-service.ts
@@ -261,7 +261,8 @@ export default class RPCService {
   // * get-a-response consumer is only one per a node and it has an exclusive queue
   protected async _consume(key: string, handler: (msg) => Promise<any>): Promise<IConsumerInfo> {
     const channel = await this.channelPool.acquireChannel();
-    await channel.prefetch(+process.env.RPC_PREFETCH || 1000);
+    const prefetchCount = await this.channelPool.getPrefetchCount();
+    await channel.prefetch(prefetchCount || +process.env.RPC_PREFETCH || 1000);
 
     const consumer = async msg => {
       try {


### PR DESCRIPTION
It is necessary to set a different prefetch count for each service by weighing throughput and memory requirements obtained by parallelism.

prefetch count can set as env variable, but it can be burden for publishers.
so, make it put default prefetch count in code and override them with environment variables when needed.