### PR TITLE
feat: add extra decorator 

### DIFF
--- a/src/controllers/endpoint-decorator.ts
+++ b/src/controllers/endpoint-decorator.ts
@@ -21,7 +21,7 @@ export interface EndpointOptions {
   admin?: boolean;
   ensure?: number;
   quota?: EndpointQuotaOptions;
-  extraCase?: {[key: string]: any};
+  extra?: {[key: string]: any};
 }
 
 export interface EndpointQuotaOptions {
@@ -610,10 +610,10 @@ export function admin(target, key, desc) {
 // @island.auth(0)
 // @island.extra({internal: true})
 // @island.endpoint('GET /v2/c', {})
-export function extra(extraCase: {[key: string]: any}) {
+export function extra(extra: {[key: string]: any}) {
   return (target, key, desc: PropertyDescriptor) => {
     const options = desc.value.options = (desc.value.options || {}) as EndpointOptions;
-    options.extraCase = extraCase || {};
+    options.extra = extra || {};
     if (desc.value.endpoints) {
       desc.value.endpoints.forEach(e => _.merge(e.options, options));
     }

--- a/src/controllers/endpoint-decorator.ts
+++ b/src/controllers/endpoint-decorator.ts
@@ -21,6 +21,7 @@ export interface EndpointOptions {
   admin?: boolean;
   ensure?: number;
   quota?: EndpointQuotaOptions;
+  internal?: boolean;
 }
 
 export interface EndpointQuotaOptions {
@@ -587,7 +588,7 @@ export function auth(level: number) {
 }
 
 // - EndpointOptions#level, EndpointOptions#admin 속성의 Syntactic Sugar 이다
-//
+// - EndpointOptions#interval admin API의 호출을 내부망의 전용 gateway를 통해서만 통신할 수 있도록 한다
 // [EXAMPLE]
 // @island.endpoint('GET /v2/a', {})
 // @island.admin
@@ -596,6 +597,22 @@ export function admin(target, key, desc) {
   const options = desc.value.options = (desc.value.options || {}) as EndpointOptions;
   options.level = Math.max(options.level || 0, 9);
   options.admin = true;
+  options.internal = true;
+  if (desc.value.endpoints) {
+    desc.value.endpoints.forEach(e => {
+      _.merge(e.options, options);
+    });
+  }
+}
+
+// - admin API 이외에 내부망의 전용 gateway를 통해서만 통신해야만 하는 endpoint에 사용한다.
+//
+// [EXAMPLE]
+// @island.internal()
+// @island.endpoint('GET /v2/c', {})
+export function internal(target, key, desc) {
+  const options = desc.value.options = (desc.value.options || {}) as EndpointOptions;
+  options.internal = true;
   if (desc.value.endpoints) {
     desc.value.endpoints.forEach(e => {
       _.merge(e.options, options);

--- a/src/controllers/endpoint-decorator.ts
+++ b/src/controllers/endpoint-decorator.ts
@@ -21,7 +21,7 @@ export interface EndpointOptions {
   admin?: boolean;
   ensure?: number;
   quota?: EndpointQuotaOptions;
-  extraCase?: string[];
+  extraCase?: {[key: string]: any};
 }
 
 export interface EndpointQuotaOptions {
@@ -581,8 +581,6 @@ export function auth(level: number) {
   return (target, key, desc: PropertyDescriptor) => {
     const options = desc.value.options = (desc.value.options || {}) as EndpointOptions;
     options.level = Math.max(options.level || 0, level);
-    options.extraCase = options.level === 9
-      ? _.union(['internal'], options.extraCase || []) : (options.extraCase || []);
     if (desc.value.endpoints) {
       desc.value.endpoints.forEach(e => _.merge(e.options, options));
     }
@@ -590,7 +588,6 @@ export function auth(level: number) {
 }
 
 // - EndpointOptions#level, EndpointOptions#admin 속성의 Syntactic Sugar 이다
-// - EndpointOptions#interval admin API의 호출을 내부망의 전용 gateway를 통해서만 통신할 수 있도록 한다
 // [EXAMPLE]
 // @island.endpoint('GET /v2/a', {})
 // @island.admin
@@ -599,7 +596,6 @@ export function admin(target, key, desc) {
   const options = desc.value.options = (desc.value.options || {}) as EndpointOptions;
   options.level = Math.max(options.level || 0, 9);
   options.admin = true;
-  options.extraCase = _.union(['internal'], options.extraCase || []);
   if (desc.value.endpoints) {
     desc.value.endpoints.forEach(e => {
       _.merge(e.options, options);
@@ -609,16 +605,15 @@ export function admin(target, key, desc) {
 
 // - 예외적인 케이스로 인해 특정 endpoint의 호출을 제어하고자 할 때 사용 한다
 // - 2017.07.21
-// - nosession, devonly도 점차적으로 extra데코레이터를 쓰도록 가이드해야 한다
-// - 향후에 옵션으로 쓰이는 녀석들 중에 grouping 가능한 것들끼리 묶어서 좀 더 잘 구현해야.. 아직은 잘 그려지지가 않음 ㅠㅠ
+// - nosession, devonly도 점차적으로 extra 데코레이터를 쓰도록 가이드해야 한다
 // [EXAMPLE] admin API 이외에 내부망의 전용 gateway를 통해서만 통신해야만 하는 endpoint의 경우
 // @island.auth(0)
-// @island.extra(['internal'])
+// @island.extra({internal: true})
 // @island.endpoint('GET /v2/c', {})
-export function extra(extraCase: string[]) {
+export function extra(extraCase: {[key: string]: any}) {
   return (target, key, desc: PropertyDescriptor) => {
     const options = desc.value.options = (desc.value.options || {}) as EndpointOptions;
-    options.extraCase = extraCase || [];
+    options.extraCase = extraCase || {};
     if (desc.value.endpoints) {
       desc.value.endpoints.forEach(e => _.merge(e.options, options));
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,7 +41,7 @@ export {
   validate,
   sanitize,
   admin,
-  internal,
+  extra,
   auth,
   devonly,
   mangle,

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,6 +41,7 @@ export {
   validate,
   sanitize,
   admin,
+  internal,
   auth,
   devonly,
   mangle,

--- a/src/spec/endpoint-decorator.spec.ts
+++ b/src/spec/endpoint-decorator.spec.ts
@@ -38,7 +38,7 @@ describe('@endpoint', () => {
   it('auth, admin, devonly Test ', () => {
     expect(fakeDecorate2(island.auth(10))).toEqual({ options: { level: 10 } });
     expect(fakeDecorate2(island.admin)).toEqual({ options: { level: 9, admin: true } });
-    expect(fakeDecorate2(island.extra({internal: true}))).toEqual({ options: { extraCase: { internal: true } } });
+    expect(fakeDecorate2(island.extra({internal: true}))).toEqual({ options: { extra: { internal: true } } });
     expect(fakeDecorate2(island.devonly)).toEqual({ options: { developmentOnly: true } });
     expect(fakeDecorate2(island.ensure(island.EnsureOptions.SESSION))).toEqual({ options: { ensure: 2 } });
     expect(fakeDecorate2(island.nosession())).toEqual({ options: { ignoreSession: true } });

--- a/src/spec/endpoint-decorator.spec.ts
+++ b/src/spec/endpoint-decorator.spec.ts
@@ -37,7 +37,8 @@ describe('@endpoint', () => {
   });
   it('auth, admin, devonly Test ', () => {
     expect(fakeDecorate2(island.auth(10))).toEqual({ options: { level: 10 } });
-    expect(fakeDecorate2(island.admin)).toEqual({ options: { level: 9, admin: true } });
+    expect(fakeDecorate2(island.admin)).toEqual({ options: { level: 9, admin: true, internal: true } });
+    expect(fakeDecorate2(island.internal)).toEqual({ options: { internal: true } });
     expect(fakeDecorate2(island.devonly)).toEqual({ options: { developmentOnly: true } });
     expect(fakeDecorate2(island.ensure(island.EnsureOptions.SESSION))).toEqual({ options: { ensure: 2 } });
     expect(fakeDecorate2(island.nosession())).toEqual({ options: { ignoreSession: true } });

--- a/src/spec/endpoint-decorator.spec.ts
+++ b/src/spec/endpoint-decorator.spec.ts
@@ -36,9 +36,9 @@ describe('@endpoint', () => {
     expect(() => fakeDecorate(island.endpoint.get('POST /test')).name).toThrowError(FatalError, /.*10010024.*/);
   });
   it('auth, admin, devonly Test ', () => {
-    expect(fakeDecorate2(island.auth(10))).toEqual({ options: { level: 10 } });
-    expect(fakeDecorate2(island.admin)).toEqual({ options: { level: 9, admin: true, internal: true } });
-    expect(fakeDecorate2(island.internal)).toEqual({ options: { internal: true } });
+    expect(fakeDecorate2(island.auth(10))).toEqual({ options: { level: 10, extraCase: [] } });
+    expect(fakeDecorate2(island.admin)).toEqual({ options: { level: 9, admin: true, extraCase: ['internal'] } });
+    expect(fakeDecorate2(island.extra(['internal']))).toEqual({ options: { extraCase: ['internal'] } });
     expect(fakeDecorate2(island.devonly)).toEqual({ options: { developmentOnly: true } });
     expect(fakeDecorate2(island.ensure(island.EnsureOptions.SESSION))).toEqual({ options: { ensure: 2 } });
     expect(fakeDecorate2(island.nosession())).toEqual({ options: { ignoreSession: true } });

--- a/src/spec/endpoint-decorator.spec.ts
+++ b/src/spec/endpoint-decorator.spec.ts
@@ -36,9 +36,9 @@ describe('@endpoint', () => {
     expect(() => fakeDecorate(island.endpoint.get('POST /test')).name).toThrowError(FatalError, /.*10010024.*/);
   });
   it('auth, admin, devonly Test ', () => {
-    expect(fakeDecorate2(island.auth(10))).toEqual({ options: { level: 10, extraCase: [] } });
-    expect(fakeDecorate2(island.admin)).toEqual({ options: { level: 9, admin: true, extraCase: ['internal'] } });
-    expect(fakeDecorate2(island.extra(['internal']))).toEqual({ options: { extraCase: ['internal'] } });
+    expect(fakeDecorate2(island.auth(10))).toEqual({ options: { level: 10 } });
+    expect(fakeDecorate2(island.admin)).toEqual({ options: { level: 9, admin: true } });
+    expect(fakeDecorate2(island.extra({internal: true}))).toEqual({ options: { extraCase: { internal: true } } });
     expect(fakeDecorate2(island.devonly)).toEqual({ options: { developmentOnly: true } });
     expect(fakeDecorate2(island.ensure(island.EnsureOptions.SESSION))).toEqual({ options: { ensure: 2 } });
     expect(fakeDecorate2(island.nosession())).toEqual({ options: { ignoreSession: true } });


### PR DESCRIPTION
# Overview
>  Current situation in which the admin API can be called through the public gateway is security anxiety. 
> \- tencent

-  We want to call the admin API only through the internal network communication, but it is difficult to apply the separately prepared gateway island depending on whether the admin API is activated or not.
- We thought it preferable to control the admin API calls according to the environment variables in the gateway island.
- So, We have modified the schema on island to develop environment variables that control admin API calls on the gateway island.
- Originally trying to make a decorator for internal checking as `@internal`, but implement it as `@extra`, a generic decorator for use in exceptional situations.

# Modified
- `@extra({ foo: 'bar' })` decorator is added, which is used to control calls to specific endpoints due to extra cases.
- If the `@extra({ internal: true })` decorator is added, the call is only allowed if the `ENABLE_INTERNAL_API` environment variable is `true`.

