### PR TITLE
feat: island status export file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ dist
 package
 island-*.tgz
 .nvmrc
+*status.json
 
 # Logs
 logs

--- a/README.md
+++ b/README.md
@@ -146,6 +146,9 @@ $ RABBITMQ_HOST=localhost npm test
 | `ISLAND_TRACEMQ_HOST`        | MQ(formatted by amqp URI) for TraceLog. If omitted it doesn't log |
 | `ISLAND_TRACEMQ_QUEUE`       | A queue name to log TraceLog                                      |
 | `SERIALIZE_FORMAT_PUSH`      | currently able Push format json and msgpack (Default to msgpack)  |
+| `STATUS_EXPORT`              | If it is `true`, use island-status-exporter                       |
+| `STATUS_EXPORT_TIME_MS`      | Time to save file for instance status                             |
+| `STATUS_FILE_NAME`           | island-status-exporter uses this as a name for file               |
 
 
 ## Milestones

--- a/README.md
+++ b/README.md
@@ -146,8 +146,8 @@ $ RABBITMQ_HOST=localhost npm test
 | `ISLAND_TRACEMQ_HOST`        | MQ(formatted by amqp URI) for TraceLog. If omitted it doesn't log |
 | `ISLAND_TRACEMQ_QUEUE`       | A queue name to log TraceLog                                      |
 | `SERIALIZE_FORMAT_PUSH`      | currently able Push format json and msgpack (Default to msgpack)  |
-| `STATUS_EXPORT`              | If it is `true`, use island-status-exporter                       |
-| `STATUS_EXPORT_TIME_MS`      | Time to save file for instance status                             |
+| `STATUS_EXPORT`              | If it is `true`, use island-status-exporter (Defaults to false)   |
+| `STATUS_EXPORT_TIME_MS`      | Time to save file for instance status (Defaults to 10000)         |
 | `STATUS_FILE_NAME`           | island-status-exporter uses this as a name for file               |
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "island",
-  "version": "1.9.0-dev.feat-errorcode2",
+  "version": "1.9.0-dev",
   "description": "A package suite for building microservice using TypeScript.",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
@@ -45,6 +45,7 @@
     "inversify": "2.0.0-beta.5",
     "island-di": "^1.1.0",
     "island-loggers": "^1.0.0",
+    "island-status-exporter": "*",
     "lodash": "^4.16.1",
     "mongodb-uri": "0.9.7",
     "mongoose": "^4.6.1",

--- a/src/index.ts
+++ b/src/index.ts
@@ -105,6 +105,7 @@ export {
 } from './utils/error';
 export { Events } from './utils/event';
 export { IntervalHelper } from './utils/interval-helper';
+export { exporter } from './utils/status-exporter';
 
 export { Di, ObjectWrapper, ObjectFactory } from 'island-di';
 export { Loggers } from 'island-loggers';

--- a/src/islet.ts
+++ b/src/islet.ts
@@ -5,6 +5,7 @@ import ListenableAdapter, { IListenableAdapter } from './adapters/listenable-ada
 import { bindImpliedServices } from './utils/di-bind';
 import { FatalError, ISLAND } from './utils/error';
 import { logger } from './utils/logger';
+import { exporter, STATUS_EXPORT, STATUS_EXPORT_TIME_MS } from './utils/status-exporter';
 
 import { IntervalHelper } from './utils/interval-helper';
 
@@ -112,6 +113,11 @@ export default class Islet {
 
       await Promise.all(adapters.map(adapter => adapter.postInitialize()));
       await Promise.all(adapters.map(adapter => adapter.listen()));
+
+      if (STATUS_EXPORT) {
+        logger.notice('INSTANCE STATUS SAVE START');
+        IntervalHelper.setIslandInterval(exporter.saveStatusJsonFile, STATUS_EXPORT_TIME_MS);
+      }
 
       logger.info('started');
       await this.onStarted();

--- a/src/spec/event-service.spec.ts
+++ b/src/spec/event-service.spec.ts
@@ -1,6 +1,3 @@
-process.env.STATUS_EXPORT = 'true';
-process.env.STATUS_EXPORT_TIME = 3 * 1000;
-
 import { AmqpChannelPoolService } from '../services/amqp-channel-pool-service';
 import { EventHookType, EventService } from '../services/event-service';
 import { Event, PatternSubscriber } from '../services/event-subscriber';

--- a/src/spec/event-service.spec.ts
+++ b/src/spec/event-service.spec.ts
@@ -1,3 +1,6 @@
+process.env.STATUS_EXPORT = 'true';
+process.env.STATUS_EXPORT_TIME = 3 * 1000;
+
 import { AmqpChannelPoolService } from '../services/amqp-channel-pool-service';
 import { EventHookType, EventService } from '../services/event-service';
 import { Event, PatternSubscriber } from '../services/event-subscriber';
@@ -156,4 +159,5 @@ describe('Event-hook', () => {
     });
     await eventService.publishEvent(new TestEvent('bbb'));
   }));
+
 });

--- a/src/spec/rpc.spec.ts
+++ b/src/spec/rpc.spec.ts
@@ -4,7 +4,7 @@ process.env.ISLAND_RPC_EXEC_TIMEOUT_MS = 1000;
 process.env.ISLAND_RPC_WAIT_TIMEOUT_MS = 3000;
 process.env.ISLAND_SERVICE_LOAD_TIME_MS = 1000;
 process.env.STATUS_EXPORT = 'true';
-process.env.STATUS_EXPORT_TIME = 3 * 1000;
+process.env.STATUS_EXPORT_TIME_MS = 3 * 1000;
 
 import * as Bluebird from 'bluebird';
 import * as fs from 'fs';
@@ -595,10 +595,12 @@ describe('RPC-hook', () => {
     }
   }));
 
-  it('should save statusfile', spec(async () => {
-    const fileName = exporter.initialize({ name: 'rpc.status.json' });
+  it('should specify filename and instanceId', spec(async () => {
+    const fileName = exporter.initialize({ name: 'rpc', hostname: 'test' });
     await exporter.saveStatusJsonFile();
-    const file = await fs.readFileSync(fileName);
-    expect(file).toBeDefined(file);
+    const file = await fs.readFileSync(fileName, 'utf8');
+    const json = JSON.parse(file);
+    await fs.unlinkSync(fileName);
+    expect(json.instanceId).toBeDefined('test');
   }));
 });

--- a/src/spec/rpc.spec.ts
+++ b/src/spec/rpc.spec.ts
@@ -3,8 +3,11 @@ require('source-map-support').install();
 process.env.ISLAND_RPC_EXEC_TIMEOUT_MS = 1000;
 process.env.ISLAND_RPC_WAIT_TIMEOUT_MS = 3000;
 process.env.ISLAND_SERVICE_LOAD_TIME_MS = 1000;
+process.env.STATUS_EXPORT = 'true';
+process.env.STATUS_EXPORT_TIME = 3 * 1000;
 
 import * as Bluebird from 'bluebird';
+import * as fs from 'fs';
 
 import { RpcOptions } from '../controllers/rpc-decorator';
 import paramSchemaInspector from '../middleware/schema.middleware';
@@ -13,6 +16,7 @@ import RPCService, { RpcHookType, RpcRequest, RpcResponse } from '../services/rp
 import { AbstractEtcError, AbstractFatalError, AbstractLogicError, FatalError, ISLAND } from '../utils/error';
 import { jasmineAsyncAdapter as spec } from '../utils/jasmine-async-support';
 import { logger } from '../utils/logger';
+import { exporter } from '../utils/status-exporter';
 import { TraceLog } from '../utils/tracelog';
 
 // tslint:disable-next-line no-var-requires
@@ -589,5 +593,12 @@ describe('RPC-hook', () => {
       expect(e.extra.message).toEqual('pre-hooked');
       expect(haveBeenCalled).toBeTruthy();
     }
+  }));
+
+  it('should save statusfile', spec(async () => {
+    const fileName = exporter.initialize({ name: 'rpc.status.json' });
+    await exporter.saveStatusJsonFile();
+    const file = await fs.readFileSync(fileName);
+    expect(file).toBeDefined(file);
   }));
 });

--- a/src/utils/status-exporter.ts
+++ b/src/utils/status-exporter.ts
@@ -1,0 +1,12 @@
+import { StatusExporter } from 'island-status-exporter';
+
+export const STATUS_EXPORT: boolean = process.env.STATUS_EXPORT === 'true';
+export const STATUS_EXPORT_TIME_MS: number = parseInt(process.env.STATUS_EXPORT_TIME, 10) || 10 * 1000;
+const STATUS_FILE_NAME: string = process.env.STATUS_FILE_NAME;
+const HOST_NAME: string = process.env.HOSTNAME;
+const SERVICE_NAME: string = process.env.SERVICE_NAME;
+
+if (STATUS_EXPORT)
+  StatusExporter.initialize({ name: STATUS_FILE_NAME, hostname: HOST_NAME, servicename: SERVICE_NAME });
+
+export const exporter = StatusExporter;

--- a/src/utils/status-exporter.ts
+++ b/src/utils/status-exporter.ts
@@ -1,7 +1,7 @@
 import { StatusExporter } from 'island-status-exporter';
 
 export const STATUS_EXPORT: boolean = process.env.STATUS_EXPORT === 'true';
-export const STATUS_EXPORT_TIME_MS: number = parseInt(process.env.STATUS_EXPORT_TIME, 10) || 10 * 1000;
+export const STATUS_EXPORT_TIME_MS: number = parseInt(process.env.STATUS_EXPORT_TIME_MS, 10) || 10 * 1000;
 const STATUS_FILE_NAME: string = process.env.STATUS_FILE_NAME;
 const HOST_NAME: string = process.env.HOSTNAME;
 const SERVICE_NAME: string = process.env.SERVICE_NAME;


### PR DESCRIPTION
## **Add monitoring module to island**
- [island-status-exporter](https://github.com/spearhead-ea/island-status-exporter/pull/1)
- use island-status-exporter module for data collection.

## **save json file**
```
{
  "cpu": 19.1,
  "memory": 51.36,
  "measurements": [
    {
      "type": "rpc",
      "tps": 1.33,
      "rps": 2.75,
      "AvgReceiveMessageTimeByMQ": 135.63,
      "AvgExecutionTime": 16.41
    }
  ],
  "savedAt": "2017-07-25T05:06:38.688Z",
  "instanceId": "localhost"
}
```

RELEASE_CANDIDATE
