### PR TITLE
feat. use 'DebugEvent' to set the timestamp value. RELEASE_CANDIDATE

### DIFF
--- a/src/services/event-service.ts
+++ b/src/services/event-service.ts
@@ -129,7 +129,7 @@ export class EventService {
         tattoo,
         from: { node: process.env.HOSTNAME, context, island: this.serviceName, type }
       },
-      timestamp: +new Date()
+      timestamp: +event.publishedAt || +new Date()
     };
     return Promise.resolve(Bluebird.try(() => new Buffer(JSON.stringify(event.args), 'utf8'))
       .then(content => {

--- a/src/services/event-subscriber.ts
+++ b/src/services/event-subscriber.ts
@@ -12,6 +12,17 @@ export class BaseEvent<T> implements Event<T> {
   }
 }
 
+export class DebugBaseEvent<T> implements Event<T> {
+  constructor(public key: string, public args: T, public publishedAt?: Date) {
+  }
+}
+
+export class DebugEvent<T> extends DebugBaseEvent<T> {
+  constructor(public debugClass: { key: string, args: T }, public publishedAt?: Date) {
+    super(debugClass.key, debugClass.args, publishedAt);
+  }
+}
+
 export interface EventHandler<T> {
   (event: T): Promise<any> | any;
 }

--- a/src/spec/event-service.spec.ts
+++ b/src/spec/event-service.spec.ts
@@ -1,16 +1,10 @@
 import { AmqpChannelPoolService } from '../services/amqp-channel-pool-service';
 import { EventHookType, EventService } from '../services/event-service';
-import { Event, PatternSubscriber } from '../services/event-subscriber';
+import { BaseEvent, DebugEvent, PatternSubscriber } from '../services/event-subscriber';
 import { jasmineAsyncAdapter as spec } from '../utils/jasmine-async-support';
 import { TraceLog } from '../utils/tracelog';
 
 import Bluebird = require('bluebird');
-
-class BaseEvent<T> implements Event<T> {
-  publishedAt: Date;
-  constructor(public key: string, public args: T) {
-  }
-}
 
 class TestEvent extends BaseEvent<string> {
   constructor(args: string) {
@@ -50,6 +44,15 @@ describe('EventService', () => {
       setTimeout(done, 500);
     })
       .then(() => eventService.publishEvent(new TestEvent('bbb')))
+      .catch(done.fail);
+  });
+
+  it('can change publishedAt for debug', done => {
+    eventService.subscribeEvent(TestEvent, (event: TestEvent) => {
+      expect(event.args).toBe('bbb');
+      setTimeout(done, 500);
+    })
+      .then(() => eventService.publishEvent(new DebugEvent(new TestEvent('bbb'), new Date(1004))))
       .catch(done.fail);
   });
 

--- a/src/spec/push-service.spec.ts
+++ b/src/spec/push-service.spec.ts
@@ -57,7 +57,7 @@ describe('PushService test : ', () => {
     const msg = 'testMessage';
     amqpChannelPool.usingChannel(channel => {
       return channel.consume(destinationQueue, content => {
-        expect(PushService.decode(content.content)).toBe('testMessage');
+        expect(PushService.decode(content && content.content)).toBe('testMessage');
       });
     }).then(() => {
       return pushService.unicast(sourceExchange, msg);
@@ -69,7 +69,7 @@ describe('PushService test : ', () => {
     const msg = 'testMessage';
     amqpChannelPool.usingChannel(channel => {
       return channel.consume(destinationQueue, content => {
-        expect(PushService.decode(content.content)).toBe('testMessage');
+        expect(PushService.decode(content && content.content)).toBe('testMessage');
       });
     }).then(() => {
       return pushService.multicast(sourceExchange, msg);


### PR DESCRIPTION
[sphd-issue #412](http://git.sphd.io/support/stt-issues/issues/412)

- If want to change the timestamp, use `DebugEvent`. This should only be used in a development environment.

# How to use DebugEvent
```
publishEvent(new DebugEvent(new UseEventClass('DebugTimeStamp'), new Date(1004)))
```

- use class and timestamp values ​​as arguments to DebugEvent. `publishedAt` changed to insert timestamp value.



