### PR TITLE
feat: support default value of sanitize Object

### DIFF
--- a/src/controllers/endpoint-decorator.ts
+++ b/src/controllers/endpoint-decorator.ts
@@ -151,18 +151,24 @@ export namespace sanitize {
     return new _String({ def, rules, minLength, maxLength, strict });
   }
 
+  export interface ObjectOpts {
+    def?: Object;
+  }
+
   // tslint:disable-next-line
   export class _Object {
     properties: { [key: string]: SanitizePropertyTypes } | undefined;
+    opts: ObjectOpts | undefined;
 
-    constructor(obj?: { [key: string]: SanitizePropertyTypes }) {
+    constructor(obj?: { [key: string]: SanitizePropertyTypes }, opts?: ObjectOpts) {
       this.properties = obj;
+      this.opts = opts;
     }
   }
 
   // tslint:disable-next-line
-  export function Object(obj: { [key: string]: SanitizePropertyTypes }) {
-    return new _Object(obj);
+  export function Object(obj: { [key: string]: SanitizePropertyTypes }, opts?: ObjectOpts) {
+    return new _Object(obj, opts);
   }
 
   // tslint:disable-next-line
@@ -211,6 +217,7 @@ export namespace sanitize {
     } else if (value instanceof _Object) {
       property.type = 'object';
       property.properties = sanitizeAsObject(value.properties);
+      _.merge(property, value.opts);
     } else if (value instanceof _Array) {
       property.type = 'array';
       property.items = sanitizeAsArray(value.items);

--- a/src/controllers/endpoint-decorator.ts
+++ b/src/controllers/endpoint-decorator.ts
@@ -151,23 +151,25 @@ export namespace sanitize {
     return new _String({ def, rules, minLength, maxLength, strict });
   }
 
-  export interface ObjectOpts {
+  // tslint:disable-next-line
+  export interface __Object {
     def?: Object;
   }
 
   // tslint:disable-next-line
   export class _Object {
     properties: { [key: string]: SanitizePropertyTypes } | undefined;
-    opts: ObjectOpts | undefined;
+    def?: Object;
 
-    constructor(obj?: { [key: string]: SanitizePropertyTypes }, opts?: ObjectOpts) {
+    constructor(obj?: { [key: string]: SanitizePropertyTypes }, opts?: __Object | undefined) {
+      opts = opts || {};
       this.properties = obj;
-      this.opts = opts;
+      this.def = opts.def;
     }
   }
 
   // tslint:disable-next-line
-  export function Object(obj: { [key: string]: SanitizePropertyTypes }, opts?: ObjectOpts) {
+  export function Object(obj: { [key: string]: SanitizePropertyTypes }, opts?: __Object) {
     return new _Object(obj, opts);
   }
 
@@ -217,7 +219,7 @@ export namespace sanitize {
     } else if (value instanceof _Object) {
       property.type = 'object';
       property.properties = sanitizeAsObject(value.properties);
-      _.merge(property, value.opts);
+      _.defaults(property, value);
     } else if (value instanceof _Array) {
       property.type = 'array';
       property.items = sanitizeAsArray(value.items);

--- a/src/spec/schema-decorator.spec.ts
+++ b/src/spec/schema-decorator.spec.ts
@@ -439,6 +439,17 @@ describe('sanitize', () => {
       type: 'object'
     });
   });
+
+  it('should support default value of object', () => {
+    const result = island.sanitize.sanitize({
+      a: s.Object({ b: Number }, { def: { b: 1 } }),
+      c: s.Object({
+        d: s.Object({ e: String })
+      }, { def: { d: { e: 'string' } } })
+    });
+    expect(result.properties.a.def).toEqual({ b: 1 });
+    expect(result.properties.c.def).toEqual({ d: { e: 'string' } });
+  });
 });
 
 describe('__langid', () => {


### PR DESCRIPTION
sanitize supports `default value` of `Object type` like the under code.

```
@sanitize.body({
    extra: sanitize.Object({}, {def: {}}),
    additional: sanitize.Object({}, {def: { noError: true }})
})
```
ps. https://github.com/Atinux/schema-inspector#s_def
