### PR TITLE
Ignore failure to assert auto-delete.trigger queue

### DIFF
--- a/src/services/push-service.ts
+++ b/src/services/push-service.ts
@@ -94,9 +94,13 @@ export default class PushService {
           broadcastExchange.type, PushService.broadcastExchange.options);
       });
       await channel.assertExchange(playerPushX.name, playerPushX.type, playerPushX.options);
-      await channel.assertQueue(PushService.autoDeleteTriggerQueue.name, PushService.autoDeleteTriggerQueue.options);
       await channel.bindExchange(PushService.broadcastExchange.name.pc, PushService.broadcastExchange.name.all, '');
       await channel.bindExchange(PushService.broadcastExchange.name.mobile, PushService.broadcastExchange.name.all, '');
+      try {
+        await channel.assertQueue(PushService.autoDeleteTriggerQueue.name, PushService.autoDeleteTriggerQueue.options);
+      } catch (e) {
+        logger.info(`asserting queue ${PushService.autoDeleteTriggerQueue.name} failed, but ignored`);
+      }
     });
   }
 


### PR DESCRIPTION
while some RabbitMQ nodes which has auto-delete.trigger queue is down
and inaccessible, island can't start. It's better to start it anyway
and wait nodes for being recovered.