### PR TITLE
fixed the variable referenced incorrectly.

### DIFF
--- a/src/services/abstract-broker-service.ts
+++ b/src/services/abstract-broker-service.ts
@@ -61,7 +61,7 @@ export default class AbstractBrokerService {
           await handler(msg);
           channel.ack(msg);
         } catch (error) {
-          if (error.type && parseInt(error.type, 10) === 503) {
+          if (error.statusCode && parseInt(error.statusCode, 10) === 503) {
             setTimeout(() => {
               channel.nack(msg);
             }, 1000);


### PR DESCRIPTION
In rpc-service.ts, used as follows
```typescript
private is503(err) {
  return err.statusCode && parseInt(err.statusCode, 10) === 503;
}
```