### PR TITLE
changed consul error to FATAL error

### DIFF
--- a/src/controllers/endpoint-decorator.ts
+++ b/src/controllers/endpoint-decorator.ts
@@ -814,6 +814,8 @@ export function endpointController(registerer?: { registerEndpoint: (name: strin
 
         return this.server.register(v.name, v.handler.bind(this), 'endpoint').then(() => {
           return registerer && registerer.registerEndpoint(v.name, v.options || {}) || Promise.resolve();
+        }).catch(e => {
+          throw new FatalError(ISLAND.FATAL.F0028_CONSUL_ERROR, e.message);
         });
       }));
       return _onInitialized.apply(this);

--- a/src/controllers/rpc-decorator.ts
+++ b/src/controllers/rpc-decorator.ts
@@ -1,5 +1,7 @@
 import * as _ from 'lodash';
 
+import { FatalError, ISLAND } from '../utils/error';
+
 export interface RpcOptions {
   version?: string;
   schema?: RpcSchemaOptions;
@@ -51,6 +53,8 @@ export function rpcController(registerer?: {registerRpc: (name: string, value: a
 
         return this.server.register(v.name, v.handler.bind(this), 'rpc', v.options).then(() => {
           return registerer && registerer.registerRpc(v.name, v.options || {}) || Promise.resolve();
+        }).catch(e => {
+          throw new FatalError(ISLAND.FATAL.F0028_CONSUL_ERROR, e.message);
         });
       }));
       return _onInitialized.apply(this);

--- a/src/utils/error.ts
+++ b/src/utils/error.ts
@@ -199,6 +199,7 @@ export namespace ISLAND {
     F0024_ENDPOINT_METHOD_REDECLARED          = 24,
     F0025_MISSING_ADAPTER_OPTIONS             = 25,
     F0026_MISSING_REPLYTO_IN_RPC              = 26,
-    F0027_CONSUMER_IS_CANCELED                = 27
+    F0027_CONSUMER_IS_CANCELED                = 27,
+    F0028_CONSUL_ERROR                        = 28
   }
 }


### PR DESCRIPTION
There are 3 points to the key get/set to the consul in the island.

1. islandKeeper init
2. registering endpoint
3. registering rpc

in case 1, the following error is displayed. It does not affect the service. And this error is hard to check.
```
diagnostic_1   | [--------|05:09:34|i] started 
diagnostic_1   | (node:1) UnhandledPromiseRejectionWarning: Unhandled promise rejection (rejection id: 14): Error: Permission denied
```

in case 2, 3.  It does affect the service.
```
Error: Permission denied
    at create (/app/be/node_modules/papi/lib/errors.js:14:5)
    at Object.response (/app/be/node_modules/papi/lib/errors.js:38:15)
    at IncomingMessage.<anonymous> (/app/be/node_modules/papi/lib/client.js:579:26)
    at emitNone (events.js:91:20)
    at IncomingMessage.emit (events.js:185:7)
    at endReadableNT (_stream_readable.js:974:12)
    at /app/be/node_modules/async-listener/glue.js:188:31
    at _combinedTickCallback (internal/process/next_tick.js:80:11)
    at process._tickDomainCallback (internal/process/next_tick.js:128:9)
    at process.fallback (/app/be/node_modules/async-listener/index.js:529:15)
```
Change consul error like `Permission denied`  or `ACL not found` to island Fatal error for readability.
```
diagnostic_1   | failed to initialize { FatalError: 10010028-Permission denied
diagnostic_1   |     at AbstractError (/app/be/service/node_modules/island/src/utils/error.ts:98:5)
diagnostic_1   |     at AbstractFatalError (/app/be/service/node_modules/island/src/utils/error.ts:134:5)
diagnostic_1   |     at FatalError (/app/be/service/node_modules/island/src/utils/error.ts:157:5)
diagnostic_1   |     at server.register.then.catch.e (/app/be/service/node_modules/island/dist/controllers/endpoint-decorator.js:616:7)
diagnostic_1   |     at propagateAslWrapper (/app/be/service/node_modules/async-listener/index.js:468:23)
diagnostic_1   |     at /app/be/service/node_modules/async-listener/glue.js:188:31
diagnostic_1   |     at proxyWrapper (/app/be/service/node_modules/async-listener/index.js:477:29)
diagnostic_1   |     at /app/be/service/node_modules/async-listener/index.js:505:70
diagnostic_1   |     at /app/be/service/node_modules/async-listener/glue.js:188:31
diagnostic_1   |     at process._tickCallback (internal/process/next_tick.js:103:7)
diagnostic_1   | From previous event:
diagnostic_1   |     at Immediate.<anonymous> (/app/be/service/node_modules/async-listener/glue.js:188:31)
diagnostic_1   |     at runCallback (timers.js:637:20)
diagnostic_1   |     at tryOnImmediate (timers.js:610:5)
diagnostic_1   |     at processImmediate [as _immediateCallback] (timers.js:582:5)
diagnostic_1   | From previous event:
diagnostic_1   |     at Promise.then (/app/be/service/node_modules/cls-bluebird/lib/shimMethod.js:38:20)
diagnostic_1   |     at Promise.all._controllersClasses.map.ControllerClass (/app/be/service/node_modules/island/src/adapters/listenable-adapter.ts:43:49)
diagnostic_1   |     at Array.map (native)
diagnostic_1   |     at RPCAdapter.postInitialize (/app/be/service/node_modules/island/src/adapters/listenable-adapter.ts:40:49)
diagnostic_1   |     at Promise.all.adapters.map.adapter (/app/be/service/node_modules/island/src/islet.ts:114:57)
diagnostic_1   |     at Array.map (native)
diagnostic_1   |     at diagnosticIslet.<anonymous> (/app/be/service/node_modules/island/src/islet.ts:114:34)
diagnostic_1   |     at next (native)
diagnostic_1   |     at fulfilled (/app/be/service/node_modules/island/dist/islet.js:4:58)
diagnostic_1   |     at propagateAslWrapper (/app/be/service/node_modules/async-listener/index.js:468:23)
diagnostic_1   |     at /app/be/service/node_modules/async-listener/glue.js:188:31
diagnostic_1   |     at /app/be/service/node_modules/async-listener/index.js:505:70
diagnostic_1   |     at /app/be/service/node_modules/async-listener/glue.js:188:31
diagnostic_1   |   code: 10010028,
diagnostic_1   |   reason: 'Permission denied',
diagnostic_1   |   extra: { uuid: '7953d723-8532-4a9f-9d0a-1d35990446f7' },
diagnostic_1   |   name: 'FatalError' }
```