### PR TITLE
feat: FORMALIZATION_FORMAT_PUSH

### DIFF
--- a/src/services/push-service.ts
+++ b/src/services/push-service.ts
@@ -5,6 +5,7 @@ import MessagePack from '../utils/msgpack';
 import { AmqpChannelPoolService } from './amqp-channel-pool-service';
 
 const SERIALIZE_FORMAT_PUSH = process.env.SERIALIZE_FORMAT_PUSH;
+const FORMALIZATION_FORMAT_PUSH = process.env.FORMALIZATION_FORMAT_PUSH;
 export type BroadcastTarget = 'all' | 'pc' | 'mobile';
 export const BroadcastTargets = ['all', 'pc', 'mobile'];
 
@@ -34,6 +35,9 @@ export default class PushService {
 
   public static encode(obj): Buffer {
     try {
+      if (FORMALIZATION_FORMAT_PUSH) {
+        obj = JSON.parse(global.eval('`' + FORMALIZATION_FORMAT_PUSH + '`'));
+      }
       let buf;
       switch (SERIALIZE_FORMAT_PUSH) {
         case 'json':


### PR DESCRIPTION
http://git.sphd.io/support/stt-issues/issues/854

support `FORMALIZATION_FORMAT_PUSH`

use Template string

It is used as follows.

```
FORMALIZATION_FORMAT_PUSH = '{"type":"push_all", "resource": [{"resource": "ToastMessage", "path": "$", "body": { "cmd": ${obj.cmd}}, "resource":${JSON.stringify(obj.opts)}}]}'
```