### PR TITLE
Add magic prefix into push packets

### DIFF
--- a/src/services/push-service.ts
+++ b/src/services/push-service.ts
@@ -41,10 +41,10 @@ export default class PushService {
       let buf;
       switch (SERIALIZE_FORMAT_PUSH) {
         case 'json':
-          buf = new Buffer(JSON.stringify(obj));
+          buf = Buffer.concat([new Buffer('JSON'), new Buffer(JSON.stringify(obj))]);
           break;
         default:
-          buf = PushService.msgpack.encode(obj);
+          buf = Buffer.concat([new Buffer('MSGP'), PushService.msgpack.encode(obj)]);
           break;
       }
       return buf;
@@ -59,13 +59,34 @@ export default class PushService {
 
   public static decode(buf) {
     let obj;
-    switch (SERIALIZE_FORMAT_PUSH) {
-      case 'json':
-        obj = JSON.parse(buf.toString());
+    let magic;
+    try {
+      magic = buf.readUInt32LE(0, 4);
+    } catch (e) {
+      // FIXME: backward compatibility
+      // we can just throw in here after all services changed.
+      magic = 0;
+    }
+    switch (magic) {
+      // JSON
+      case 0x4E4F534A:
+        obj = JSON.parse(buf.slice(4).toString());
+        break;
+      // MSGP
+      case 0x5047534D:
+        obj = PushService.msgpack.decode(buf.slice(4));
         break;
       default:
-        obj = PushService.msgpack.decode(buf);
-        break;
+        // FIXME: backward compatibility
+        // we can just throw in here after all services changed.
+        switch (SERIALIZE_FORMAT_PUSH) {
+          case 'json':
+            obj = JSON.parse(buf.toString());
+            break;
+          default:
+            obj = PushService.msgpack.decode(buf);
+            break;
+        }
     }
     return obj;
   }

--- a/src/spec/push-service.spec.ts
+++ b/src/spec/push-service.spec.ts
@@ -149,4 +149,26 @@ describe('PushService test : ', () => {
       })
       .then(done, done.fail);
   });
+
+  // FIXME: we should test with PushService, not copy logics
+  it('push test #11: PushService Decode JSON type', () => {
+    const test = { test: 1 };
+    const content = new Buffer('JSON' + JSON.stringify(test));
+    const decodeData = PushService.decode(content);
+    expect(decodeData).toEqual(test);
+  });
+
+  it('push test #12: PushService Decode msgpack type', () => {
+    const test = { test: 1 };
+    const content = Buffer.concat([new Buffer('MSGP'), msgpack.encode(test)]);
+    const decodeData = PushService.decode(content);
+    expect(decodeData).toEqual(test);
+  });
+
+  it('push test #13: PushService Decode old type msgpack type', () => {
+    const test = { test: 1 };
+    const content = msgpack.encode(test);
+    const decodeData = PushService.decode(content);
+    expect(decodeData).toEqual(test);
+  });
 });


### PR DESCRIPTION
all encoded packet should have magic number for passing encoding type.
this rule is important because, if some service misconfigure, push
service cannot decode packet.

this patch can start to detecting wrong server configuration.