### PR TITLE
feat: environment values are provided

### DIFF
--- a/src/controllers/endpoint-decorator.ts
+++ b/src/controllers/endpoint-decorator.ts
@@ -1,5 +1,5 @@
 import * as _ from 'lodash';
-
+import { Environments } from '../utils/environments';
 import { FatalError, ISLAND } from '../utils/error';
 
 export enum EnsureOptions {
@@ -828,7 +828,7 @@ export function endpointController(registerer?: {
     target.prototype.onInitialized = async function () {
       await Promise.all(_.map(target._endpointMethods, (v: Endpoint) => {
         const developmentOnly = _.get(v, 'options.developmentOnly');
-        if (developmentOnly && process.env.NODE_ENV !== 'development') return Promise.resolve();
+        if (developmentOnly && !Environments.isDevMode()) return Promise.resolve();
 
         v.name = mangle(v.name);
         return this.server.register(v.name, v.handler.bind(this), 'endpoint').then(() => {

--- a/src/controllers/rpc-decorator.ts
+++ b/src/controllers/rpc-decorator.ts
@@ -1,5 +1,5 @@
 import * as _ from 'lodash';
-
+import { Environments } from '../utils/environments';
 import { FatalError, ISLAND } from '../utils/error';
 
 export interface RpcOptions {
@@ -49,7 +49,7 @@ export function rpcController(registerer?: {registerRpc: (name: string, value: a
     target.prototype.onInitialized = async function () {
       await Promise.all(_.map(target._endpointMethods, (v: Rpc) => {
         const developmentOnly = _.get(v, 'options.developmentOnly');
-        if (developmentOnly && process.env.NODE_ENV !== 'development') return Promise.resolve();
+        if (developmentOnly && !Environments.isDevMode()) return Promise.resolve();
 
         return this.server.register(v.name, v.handler.bind(this), 'rpc', v.options).then(() => {
           return registerer && registerer.registerRpc(v.name, v.options || {}) || Promise.resolve();

--- a/src/index.ts
+++ b/src/index.ts
@@ -86,6 +86,7 @@ export { EventService } from './services/event-service';
 export { Event, BaseEvent } from './services/event-subscriber';
 
 // utils
+export { Environments } from './utils/environments';
 export { TraceLog } from './utils/tracelog';
 export { ScopeExit } from './utils/scope-exit';
 export { ResourcePush } from './utils/resource-push';

--- a/src/services/event-service.ts
+++ b/src/services/event-service.ts
@@ -5,6 +5,7 @@ import * as Bluebird from 'bluebird';
 import * as _ from 'lodash';
 import * as uuid from 'uuid';
 
+import { Environments } from '../utils/environments';
 import { Events } from '../utils/event';
 import { logger } from '../utils/logger';
 import reviver from '../utils/reviver';
@@ -135,7 +136,7 @@ export class EventService {
     const options = {
       headers: {
         tattoo,
-        from: { node: process.env.HOSTNAME, context, island: this.serviceName, type },
+        from: { node: Environments.getHostName(), context, island: this.serviceName, type },
         extra: { sessionType }
       },
       timestamp: +event.publishedAt || +new Date()
@@ -153,7 +154,7 @@ export class EventService {
 
   private registerConsumer(channel: amqp.Channel, queue: string): Promise<any> {
     const prefetchCount = this.channelPool.getPrefetchCount();
-    return Promise.resolve(channel.prefetch(prefetchCount || +process.env.EVENT_PREFETCH || 100))
+    return Promise.resolve(channel.prefetch(prefetchCount || Environments.getEventPrefetch()))
       .then(() => channel.consume(queue, msg => {
         if (!msg) {
           logger.error(`consume was canceled unexpectedly`);
@@ -225,7 +226,7 @@ export class EventService {
         log.to = {
           context: msg.fields.routingKey,
           island: this.serviceName,
-          node: process.env.HOSTNAME,
+          node: Environments.getHostName(),
           type: 'event'
         };
 

--- a/src/services/push-service.ts
+++ b/src/services/push-service.ts
@@ -1,10 +1,11 @@
 import * as _ from 'lodash';
+import { Environments } from '../utils/environments';
 import { ISLAND, LogicError } from '../utils/error';
 import { logger } from '../utils/logger';
 import MessagePack from '../utils/msgpack';
 import { AmqpChannelPoolService } from './amqp-channel-pool-service';
 
-const SERIALIZE_FORMAT_PUSH = process.env.SERIALIZE_FORMAT_PUSH;
+const SERIALIZE_FORMAT_PUSH = Environments.getSerializeFormatPush();
 export type BroadcastTarget = 'all' | 'pc' | 'mobile';
 export const BroadcastTargets = ['all', 'pc', 'mobile'];
 

--- a/src/utils/environments.ts
+++ b/src/utils/environments.ts
@@ -1,0 +1,68 @@
+export class Environments {
+  static isDevMode(): boolean {
+    return process.env.USE_DEV_MODE === 'true';
+  }
+
+  static getHostName(): string {
+    return process.env.HOSTNAME;
+  }
+
+  static getServiceName(): string {
+    return process.env.SERVICE_NAME;
+  }
+
+  static getEventPrefetch(): number {
+    return +process.env.EVENT_PREFETCH || 100;
+  }
+
+  static getRpcPrefetch(): number {
+    return +process.env.RPC_PREFETCH || 100;
+  }
+
+  static getSerializeFormatPush(): string {
+    return process.env.SERIALIZE_FORMAT_PUSH;
+  }
+
+  static getIslandRpcExecTimeoutMs(): number {
+    return parseInt(process.env.ISLAND_RPC_EXEC_TIMEOUT_MS, 10) || 25000;
+  }
+
+  static getIslandRpcWaitTimeoutMs(): number {
+    return parseInt(process.env.ISLAND_RPC_WAIT_TIMEOUT_MS, 10) || 60000;
+  }
+
+  static getIslandServiceLoadTimeMs(): number {
+    return parseInt(process.env.ISLAND_SERVICE_LOAD_TIME_MS, 10) || 60000;
+  }
+
+  static isIslandRpcResNoack(): boolean {
+    return process.env.ISLAND_RPC_RES_NOACK === 'true';
+  }
+
+  static isNoReviver(): boolean {
+    return process.env.NO_REVIVER === 'true';
+  }
+
+  static getIslandLoggerLevel(): 'debug' | 'info' | 'notice' | 'warning' | 'error' | 'crit' {
+    return process.env.ISLAND_LOGGER_LEVEL || 'info';
+  }
+  static isStatusExport(): boolean {
+    return process.env.STATUS_EXPORT === 'true';
+  }
+
+  static getStatusExportTimeMs(): number {
+    return parseInt(process.env.STATUS_EXPORT_TIME_MS, 10) || 10 * 1000;
+  }
+
+  static getStatusFileName(): string {
+    return process.env.STATUS_FILE_NAME;
+  }
+
+  static getIslandTracemqHost(): string {
+    return process.env.ISLAND_TRACEMQ_HOST;
+  }
+
+  static getIslandTracemqQueue(): string {
+    return process.env.ISLAND_TRACEMQ_QUEUE || 'trace';
+  }
+}

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,5 +1,6 @@
 import { Loggers } from 'island-loggers';
 import * as winston from 'winston';
+import { Environments } from '../utils/environments';
 
 export const logger: winston.LoggerInstance = Loggers.get('island');
-Loggers.switchLevel('island', process.env.ISLAND_LOGGER_LEVEL || 'info');
+Loggers.switchLevel('island', Environments.getIslandLoggerLevel());

--- a/src/utils/status-exporter.ts
+++ b/src/utils/status-exporter.ts
@@ -1,10 +1,11 @@
 import { StatusExporter } from 'island-status-exporter';
+import { Environments } from '../utils/environments';
 
-export const STATUS_EXPORT: boolean = process.env.STATUS_EXPORT === 'true';
-export const STATUS_EXPORT_TIME_MS: number = parseInt(process.env.STATUS_EXPORT_TIME_MS, 10) || 10 * 1000;
-const STATUS_FILE_NAME: string = process.env.STATUS_FILE_NAME;
-const HOST_NAME: string = process.env.HOSTNAME;
-const SERVICE_NAME: string = process.env.SERVICE_NAME;
+export const STATUS_EXPORT: boolean = Environments.isStatusExport();
+export const STATUS_EXPORT_TIME_MS: number = Environments.getStatusExportTimeMs();
+const STATUS_FILE_NAME: string = Environments.getStatusFileName();
+const HOST_NAME: string = Environments.getHostName();
+const SERVICE_NAME: string = Environments.getServiceName();
 
 if (STATUS_EXPORT)
   StatusExporter.initialize({ name: STATUS_FILE_NAME, hostname: HOST_NAME, servicename: SERVICE_NAME });


### PR DESCRIPTION
If the  value of `NODE_ENV` is development, it is judged to be in a development state.

However, the value of `NODE_ENV ` is a problem because it is commonly used.

Use value of `USE_DEV_MODE` instead of value of `NODE_ENV` to see if it is a development environment.

Provides the value of island environments as function.

It can be used as follows.

```
const devMode = island.Environments.isDevMode();
```




  