### PR TITLE
feat : ongoingRequest detail info

### DIFF
--- a/src/adapters/abstract-adapter.ts
+++ b/src/adapters/abstract-adapter.ts
@@ -8,6 +8,7 @@ export interface IAbstractAdapter {
   adaptee: any;
   initialize(): any | Promise<any>;
   destroy(): any | Promise<any>;
+  sigInfo(): any | Promise<void>;
 }
 
 /**
@@ -32,6 +33,10 @@ export default class AbstractAdapter<T, U> implements IAbstractAdapter {
   }
 
   public destroy(): any | Promise<any> {
+    throw new FatalError(ISLAND.FATAL.F0004_NOT_IMPLEMENTED_ERROR, 'Not implemented error');
+  }
+
+  public async sigInfo(): Promise<void> {
     throw new FatalError(ISLAND.FATAL.F0004_NOT_IMPLEMENTED_ERROR, 'Not implemented error');
   }
 }

--- a/src/adapters/impl/event-adapter.ts
+++ b/src/adapters/impl/event-adapter.ts
@@ -28,4 +28,8 @@ export class EventAdapter extends ListenableAdapter<EventService, EventAdapterOp
     await super.destroy();
     return this.adaptee.purge();
   }
+
+  async sigInfo(): Promise<void> {
+    await this.adaptee.sigInfo();
+  }
 }

--- a/src/adapters/impl/rpc-adapter.ts
+++ b/src/adapters/impl/rpc-adapter.ts
@@ -50,4 +50,8 @@ export default class RPCAdapter extends ListenableAdapter<RPCService, RPCAdapter
   registerHook(type: RpcHookType, hook: RpcHook) {
     this.hooks.push({type, hook});
   }
+
+  async sigInfo(): Promise<void> {
+    await this.adaptee.sigInfo();
+  }
 }

--- a/src/spec/event-service.spec.ts
+++ b/src/spec/event-service.spec.ts
@@ -160,4 +160,14 @@ describe('Event-hook', () => {
     await eventService.publishEvent(new TestEvent('bbb'));
   }));
 
+  it('could check the onGoingRequest', spec(async () => {
+    eventService.registerHook(EventHookType.EVENT, p => {
+      return Promise.resolve('x' + p);
+    });
+    await eventService.subscribeEvent(TestEvent, (event: TestEvent) => {
+      expect(event.args).toBe('xbbb');
+    });
+    await eventService.publishEvent(new TestEvent('bbb'));
+    await eventService.sigInfo();
+  }));
 });

--- a/src/spec/rpc.spec.ts
+++ b/src/spec/rpc.spec.ts
@@ -632,4 +632,13 @@ describe('RPC-hook', () => {
     await fs.unlinkSync(fileName);
     expect(json.instanceId).toBeDefined('test');
   }));
+
+  it('could check the onGoingRequest', spec(async () => {
+    rpcService.registerHook(RpcHookType.PRE_RPC, content => Promise.resolve('hi, ' + content));
+    await rpcService.register('testMethod', msg => Promise.resolve(msg + ' world'), 'rpc');
+    await rpcService.listen();
+    const res = await rpcService.invoke('testMethod', 'hello');
+    expect(res).toEqual('hi, hello world');
+    await rpcService.sigInfo();
+  }));
 });


### PR DESCRIPTION
When a `SIGUSR2(12)` signal occurs,

shows the details of the requests being processed.

```
root@637c222e8847:/app/be/service# kill -12 1

[--------|11:33:53|i] Waiting for a check to process status 
[--------|11:33:53|d] sigInfo :  rpc 
[--------|11:33:53|i] RPC Service onGoingRequestCount : 0 
[--------|11:33:53|d] sigInfo :  event 
[--------|11:33:53|i] RPC Service Info 
[--------|11:33:53|i] RPC Service onGoingRequestCount : 0 
[--------|11:33:53|d] sigInfo :  push 
```