### PR TITLE
feat: restrict console log for cron

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ $ RABBITMQ_HOST=localhost npm test
 | `ISLAND_RPC_WAIT_TIMEOUT_MS` | Timeout during call (Defaults to 60000)                           |
 | `ISLAND_SERVICE_LOAD_TIME_MS`| Time to load service (Defaults to 60000)                          |
 | `ISLAND_LOGGER_LEVEL`        | Logger level of category `island`                                 |
-| `ISLAND_LOGGER_CRON`         | If it is `true`, console log output for cron (Default to `false`) |
+| `ISLAND_IGNORE_EVENT_LOG`    | Ignore the log for Event containing this Env (template is `A,B`)  |
 | `ISLAND_TRACEMQ_HOST`        | MQ(formatted by amqp URI) for TraceLog. If omitted it doesn't log |
 | `ISLAND_TRACEMQ_QUEUE`       | A queue name to log TraceLog                                      |
 | `SERIALIZE_FORMAT_PUSH`      | currently able Push format json and msgpack (Default to msgpack)  |

--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ $ RABBITMQ_HOST=localhost npm test
 | `ISLAND_RPC_WAIT_TIMEOUT_MS` | Timeout during call (Defaults to 60000)                           |
 | `ISLAND_SERVICE_LOAD_TIME_MS`| Time to load service (Defaults to 60000)                          |
 | `ISLAND_LOGGER_LEVEL`        | Logger level of category `island`                                 |
+| `ISLAND_LOGGER_CRON`         | If it is `true`, console log output for cron (Default to `false`) |
 | `ISLAND_TRACEMQ_HOST`        | MQ(formatted by amqp URI) for TraceLog. If omitted it doesn't log |
 | `ISLAND_TRACEMQ_QUEUE`       | A queue name to log TraceLog                                      |
 | `SERIALIZE_FORMAT_PUSH`      | currently able Push format json and msgpack (Default to msgpack)  |

--- a/src/services/event-service.ts
+++ b/src/services/event-service.ts
@@ -59,6 +59,7 @@ export class EventService {
   private onGoingEventRequestCount: number = 0;
   private purging: Function | null = null;
   private consumerInfosMap: { [name: string]: IEventConsumerInfo } = {};
+  private cronRegex = new RegExp(/cron/g);
 
   constructor(serviceName: string) {
     this.serviceName = serviceName;
@@ -219,7 +220,9 @@ export class EventService {
       const clsProperties = _.merge({ RequestTrackId: tattoo, Context: msg.fields.routingKey, Type: 'event' },
                                     extra);
       return enterScope(clsProperties, () => {
-        logger.debug(`${msg.fields.routingKey}`, content, msg.properties.headers);
+        if (Environments.getIslandLoggerCron() || !msg.fields.routingKey.match(this.cronRegex)) {
+          logger.debug(`${msg.fields.routingKey}`, content, msg.properties.headers);
+        }
         const log = new TraceLog(tattoo, msg.properties.timestamp || 0);
         log.size = msg.content.byteLength;
         log.from = headers.from;

--- a/src/utils/environments.ts
+++ b/src/utils/environments.ts
@@ -66,7 +66,7 @@ export class Environments {
     return process.env.ISLAND_TRACEMQ_QUEUE || 'trace';
   }
 
-  static getIslandLoggerCron(): boolean {
-    return process.env.ISLAND_LOGGER_CRON === 'true';
+  static getIgnoreEventLogRegexp(): string {
+    return (process.env.ISLAND_IGNORE_EVENT_LOG || '').split(',').join('|');
   }
 }

--- a/src/utils/environments.ts
+++ b/src/utils/environments.ts
@@ -65,4 +65,8 @@ export class Environments {
   static getIslandTracemqQueue(): string {
     return process.env.ISLAND_TRACEMQ_QUEUE || 'trace';
   }
+
+  static getIslandLoggerCron(): boolean {
+    return process.env.ISLAND_LOGGER_CRON === 'true';
+  }
 }


### PR DESCRIPTION
**WHY**
* In the case of a cron event, it can also operate up to 1 second. At this time, there are too many logs for the cron event, leaving a lot of meaningless logs.

**After**
* Allows you to limit the cron event log so that no cron is logged.


release_candidate