### PR TITLE
feat: bump up typescript 2.2 to 2.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,13 +17,13 @@
     "coverage": "gulp coverage"
   },
   "dependencies": {
-    "@types/amqplib": "^0.5.0",
+    "@types/amqplib": "^0.5.7",
     "@types/bl": "^0.8.30",
-    "@types/bluebird": "3.5.5",
+    "@types/bluebird": "3.5.20",
     "@types/inversify": "2.0.32",
     "@types/jasmine": "^2.5.37",
     "@types/jsonwebtoken": "7.2.0",
-    "@types/lodash": "4.14.56",
+    "@types/lodash": "4.14.106",
     "@types/mongodb": "2.2.3",
     "@types/mongoose": "4.7.15",
     "@types/msgpack5": "^3.4.0",
@@ -46,6 +46,7 @@
     "island-di": "^1.1.0",
     "island-loggers": "^1.0.0",
     "island-status-exporter": "^2.0.0",
+    "jsonwebtoken": "^8.2.0",
     "lodash": "^4.16.1",
     "mongodb-uri": "0.9.7",
     "mongoose": "^4.6.1",
@@ -58,6 +59,7 @@
     "schema-inspector": "^1.6.6",
     "socket.io": "^1.4.8",
     "source-map-support": "^0.4.2",
+    "types": "^0.1.1",
     "uuid": "^3.0.1",
     "winston": "^2.2.0"
   },
@@ -69,7 +71,7 @@
     "gulp-tslint": "^7.0.1",
     "remap-istanbul": "^0.6.4",
     "std-mocks": "^1.0.1",
-    "tslint": "^4.3.1",
-    "typescript": "<2.2"
+    "tslint": "^5.9.1",
+    "typescript": "^2.8.1"
   }
 }

--- a/src/adapters/listenable-adapter.ts
+++ b/src/adapters/listenable-adapter.ts
@@ -22,13 +22,13 @@ export interface IListenableAdapter extends IAbstractAdapter {
  * @implements IListenableAdapter
  */
 export default class ListenableAdapter<T, U> extends AbstractAdapter<T, U> implements IListenableAdapter {
-  private _controllersClasses: typeof AbstractController[] = [];
+  private _controllersClasses: {new(...args: any[]): AbstractController<T>;}[] = [];
   private _controllers: AbstractController<T>[] = [];
 
   /**
    * @param {AbstractController} Class
    */
-  public registerController(Class: typeof AbstractController) {
+  public registerController(Class: {new(...args: any[]): AbstractController<T>;}) {
     this._controllersClasses.push(Class);
   }
 

--- a/src/controllers/endpoint-decorator.ts
+++ b/src/controllers/endpoint-decorator.ts
@@ -182,14 +182,14 @@ export namespace sanitize {
 
   // tslint:disable-next-line
   export class _Array {
-    items: [SanitizePropertyTypes];
+    items: SanitizePropertyTypes[];
 
-    constructor(items: [SanitizePropertyTypes]) {
+    constructor(items: SanitizePropertyTypes[]) {
       this.items = items;
     }
   }
 
-  export function Array(items: [SanitizePropertyTypes]) {
+  export function Array(items: SanitizePropertyTypes[]) {
     return new _Array(items);
   }
 
@@ -243,7 +243,9 @@ export namespace sanitize {
   // schema-inspector 문법은 array에 들어올 수 있는 타입을 한 개 이상 받을 수 있게 되어있지만
   // 여기서는 가장 첫번째 한 개만 처리하고 있다. 인터페이스 구조상 여러 개도 처리할 수 있지만 단순히 안 한 것 뿐이다.
   // @kson //2016-08-04
-  function sanitizeAsArray([item]) {
+  function sanitizeAsArray(items: SanitizePropertyTypes[]) {
+    if (!items) return;
+    const item = items[0];
     const property: SchemaInspectorProperty = { optional: true };
     return parseSanitization(property, item);
   }
@@ -488,16 +490,15 @@ export namespace validate {
   // schema-inspector 문법은 array에 들어올 수 있는 타입을 한 개 이상 받을 수 있게 되어있지만
   // 여기서는 가장 첫번째 한 개만 처리하고 있다. 인터페이스 구조상 여러 개도 처리할 수 있지만 단순히 안 한 것 뿐이다.
   // @kson //2016-08-04
-  function validateAsArray(items?: [ValidatePropertyTypes]) {
+  function validateAsArray(items?: ValidatePropertyTypes[]) {
     if (!items) return;
-
     const item = items[0];
     const property: SchemaInspectorProperty = { optional: false };
     return parseValidation(property, item);
   }
 
   // v.Array로 선언되어 Option이 있는 경우 이 함수가 사용된다.
-  function validateAsArrayWithOptions(obj?: { items?: [ValidatePropertyTypes], opts?: __Array }) {
+  function validateAsArrayWithOptions(obj?: { items?: ValidatePropertyTypes[], opts?: __Array }) {
     obj = obj || {};
     if (!obj.items) return;
     const item = obj.items;
@@ -510,7 +511,7 @@ export namespace validate {
         property[key] = value;
       }
     });
-    return parseValidation(property, item);
+    return parseValidation(property, item[0]);
   }
   // validation의 optional의 기본값은 false
   // https://github.com/Atinux/schema-inspector#v_optional

--- a/src/controllers/endpoint-decorator.ts
+++ b/src/controllers/endpoint-decorator.ts
@@ -196,7 +196,8 @@ export namespace sanitize {
   export type SanitizePropertyTypes =
     typeof global.String | string | _String |
     typeof global.Number | number | _Number |
-    typeof Boolean | typeof Date | _Object | _Array | _Any |
+    typeof Boolean | boolean | 
+    typeof Date | _Object | _Array | _Any |
     _ObjectId | _Cider | _NumberOrQuery;
 
   // tslint:disable-next-line cyclomatic-complexity

--- a/src/controllers/event-decorator.ts
+++ b/src/controllers/event-decorator.ts
@@ -19,13 +19,13 @@ interface PatternSubscriptionContainer {
   _patternSubscriptions: PatternSubscription[];
 }
 
-export function eventController(target: typeof AbstractController) {
+export function eventController<T>(target: any) {
   const _onInitialized = target.prototype.onInitialized;
   // tslint:disable-next-line
   target.prototype.onInitialized = async function () {
     const result = await _onInitialized.apply(this);
 
-    const constructor = target as typeof AbstractController &
+    const constructor = target as {new (): AbstractController<T>;} &
       EventSubscriptionContainer<Event<any>, any> & PatternSubscriptionContainer;
 
     constructor._eventSubscriptions = DEFAULT_SUBSCRIPTIONS.concat(constructor._eventSubscriptions || []);

--- a/src/islet.ts
+++ b/src/islet.ts
@@ -109,8 +109,8 @@ export default class Islet {
       process.on('SIGUSR2', this.sigInfo.bind(this));
       bindImpliedServices(this.adapters);
       await this.onInitialized();
-      const adapters = _.values<IListenableAdapter>(this.adapters)
-                        .filter(adapter => adapter instanceof ListenableAdapter);
+      const adapters = _.values<IAbstractAdapter>(this.adapters)
+                        .filter(adapter => adapter instanceof ListenableAdapter) as IListenableAdapter[];
 
       await Promise.all(adapters.map(adapter => adapter.postInitialize()));
       await Promise.all(adapters.map(adapter => adapter.listen()));

--- a/src/services/abstract-broker-service.ts
+++ b/src/services/abstract-broker-service.ts
@@ -17,7 +17,7 @@ export default class AbstractBrokerService {
     this.msgpack = MessagePack.getInst();
   }
 
-  public initialize() {
+  public initialize(): Promise<void | never> {
     return Promise.reject(new FatalError(ISLAND.FATAL.F0011_NOT_INITIALIZED_EXCEPTION, 'Not initialized exception'));
   }
 

--- a/src/services/amqp-channel-pool-service.ts
+++ b/src/services/amqp-channel-pool-service.ts
@@ -58,10 +58,10 @@ export class AmqpChannelPoolService {
   async acquireChannel(): Promise<amqp.Channel> {
     // In race condition, the length of idleChannels can over the requested poolSize.
     // But, we allow the little miss at here.
-    if (this.idleChannels.length < this.options.poolSize) {
+    if (this.idleChannels.length < this.options.poolSize!) {
       this.idleChannels.push(await this.createChannel());
     }
-    return _.sample(this.idleChannels);
+    return _.sample(this.idleChannels)!;
   }
 
   async releaseChannel(channel: amqp.Channel, reusable: boolean = false): Promise<void> {

--- a/src/services/event-service.ts
+++ b/src/services/event-service.ts
@@ -133,12 +133,10 @@ export class EventService {
   publishEvent<T extends Event<U>, U>(exchange: string, event: T): Promise<any>;
   publishEvent<T extends Event<U>, U>(event: T): Promise<any>;
   publishEvent(...args): Promise<any> {
-    let exchange = EventService.EXCHANGE_NAME;
     let event: Event<{}>;
     if (args.length === 1) {
       event = args[0];
     } else {
-      exchange = args[0];
       event = args[1];
     }
     const ns = cls.getNamespace('app');
@@ -153,7 +151,7 @@ export class EventService {
         from: { node: Environments.getHostName(), context, island: this.serviceName, type },
         extra: { sessionType }
       },
-      timestamp: +event.publishedAt || +new Date()
+      timestamp: +event.publishedAt! || +new Date()
     };
     return Promise.resolve(Bluebird.try(() => new Buffer(JSON.stringify(event.args), 'utf8'))
       .then(content => {
@@ -244,7 +242,7 @@ export class EventService {
         log.to = {
           context: msg.fields.routingKey,
           island: this.serviceName,
-          node: Environments.getHostName(),
+          node: Environments.getHostName()!,
           type: 'event'
         };
         return Bluebird.resolve(subscriber.handleEvent(content, msg))

--- a/src/services/rpc-service.ts
+++ b/src/services/rpc-service.ts
@@ -105,7 +105,6 @@ type DeferredResponse = { resolve: (msg: Message) => any, reject: (e: Error) => 
 export default class RPCService {
   private requestConsumerInfo: IConsumerInfo[] = [];
   private responseQueueName: string;
-  private responseConsumerInfo: IConsumerInfo;
   private waitingResponse: { [corrId: string]: DeferredResponse } = {};
   private timedOut: { [corrId: string]: string } = {};
   private timedOutOrdered: string[] = [];
@@ -146,7 +145,7 @@ export default class RPCService {
       })
     );
 
-    this.responseConsumerInfo = await this.consumeForResponse();
+    await this.consumeForResponse();
   }
 
   @deprecated()
@@ -490,7 +489,7 @@ export default class RPCService {
     }));
     await this.consumerChannelPool.usingChannel(async channel => {
       await Promise.all(_.map(bindInfos, async ({queue, rpcName, routingKey}) => {
-        await channel.bindQueue(queue, rpcName, routingKey);
+        await channel.bindQueue(queue, rpcName, routingKey!);
       }));
     });
   }

--- a/src/spec/rpc.spec.ts
+++ b/src/spec/rpc.spec.ts
@@ -1,10 +1,10 @@
 // tslint:disable-next-line
 require('source-map-support').install();
-process.env.ISLAND_RPC_EXEC_TIMEOUT_MS = 1000;
-process.env.ISLAND_RPC_WAIT_TIMEOUT_MS = 3000;
-process.env.ISLAND_SERVICE_LOAD_TIME_MS = 1000;
+process.env.ISLAND_RPC_EXEC_TIMEOUT_MS = '1000';
+process.env.ISLAND_RPC_WAIT_TIMEOUT_MS = '3000';
+process.env.ISLAND_SERVICE_LOAD_TIME_MS = '1000';
 process.env.STATUS_EXPORT = 'true';
-process.env.STATUS_EXPORT_TIME_MS = 3 * 1000;
+process.env.STATUS_EXPORT_TIME_MS = '3000';
 
 import * as Bluebird from 'bluebird';
 // import * as fs from 'fs';
@@ -224,7 +224,7 @@ describe('RPC(isolated test)', () => {
     await amqpChannelPool.initialize({ url });
     await rpcService.initialize(amqpChannelPool);
     const p = rpcService.invoke<string, string>('testMethod3', 'hello');
-    await Bluebird.delay(parseInt(process.env.ISLAND_RPC_WAIT_TIMEOUT_MS, 10) / 2);
+    await Bluebird.delay(parseInt(process.env.ISLAND_RPC_WAIT_TIMEOUT_MS as string, 10) / 2);
     await rpcService.register('testMethod3', msg => Promise.resolve('world'), 'rpc');
     await rpcService.listen();
     const res = await p;

--- a/src/spec/schema-types.spec.ts
+++ b/src/spec/schema-types.spec.ts
@@ -138,7 +138,7 @@ describe('Schema-types test:', () => {
 
   it(`test validation for string array types `, () => {
     const GAME_MODE_ARRAY1: string[] = ['ITEMINDIVIDUAL', 'ITEMTEAM', 'SPEEDINDIVIDUAL', 'SPEEDTEAM'];
-    const GAME_MODE_ARRAY2: [string] = ['ITEMINDIVIDUAL', 'ITEMTEAM', 'SPEEDINDIVIDUAL', 'SPEEDTEAM'];
+    const GAME_MODE_ARRAY2: string[] = ['ITEMINDIVIDUAL', 'ITEMTEAM', 'SPEEDINDIVIDUAL', 'SPEEDTEAM'];
 
     const result1 = island.validate.validate({ 'gameMode!': island.validate.String({ eq: GAME_MODE_ARRAY1 }) });
     expect(result1).toEqual({

--- a/src/utils/environments.ts
+++ b/src/utils/environments.ts
@@ -1,38 +1,40 @@
+export type LoggerLevel = 'debug' | 'info' | 'notice' | 'warning' | 'error' | 'crit';
+
 export class Environments {
   static isDevMode(): boolean {
     return process.env.USE_DEV_MODE === 'true';
   }
 
-  static getHostName(): string {
+  static getHostName(): string | undefined {
     return process.env.HOSTNAME;
   }
 
-  static getServiceName(): string {
+  static getServiceName(): string | undefined {
     return process.env.SERVICE_NAME;
   }
 
   static getEventPrefetch(): number {
-    return +process.env.EVENT_PREFETCH || 100;
+    return +process.env.EVENT_PREFETCH! || 100;
   }
 
   static getRpcPrefetch(): number {
-    return +process.env.RPC_PREFETCH || 100;
+    return +process.env.RPC_PREFETCH! || 100;
   }
 
-  static getSerializeFormatPush(): string {
+  static getSerializeFormatPush(): string | undefined {
     return process.env.SERIALIZE_FORMAT_PUSH;
   }
 
   static getIslandRpcExecTimeoutMs(): number {
-    return parseInt(process.env.ISLAND_RPC_EXEC_TIMEOUT_MS, 10) || 25000;
+    return parseInt(process.env.ISLAND_RPC_EXEC_TIMEOUT_MS!, 10) || 25000;
   }
 
   static getIslandRpcWaitTimeoutMs(): number {
-    return parseInt(process.env.ISLAND_RPC_WAIT_TIMEOUT_MS, 10) || 60000;
+    return parseInt(process.env.ISLAND_RPC_WAIT_TIMEOUT_MS!, 10) || 60000;
   }
 
   static getIslandServiceLoadTimeMs(): number {
-    return parseInt(process.env.ISLAND_SERVICE_LOAD_TIME_MS, 10) || 60000;
+    return parseInt(process.env.ISLAND_SERVICE_LOAD_TIME_MS!, 10) || 60000;
   }
 
   static isIslandRpcResNoack(): boolean {
@@ -43,22 +45,22 @@ export class Environments {
     return process.env.NO_REVIVER === 'true';
   }
 
-  static getIslandLoggerLevel(): 'debug' | 'info' | 'notice' | 'warning' | 'error' | 'crit' {
-    return process.env.ISLAND_LOGGER_LEVEL || 'info';
+  static getIslandLoggerLevel(): LoggerLevel {
+    return (process.env.ISLAND_LOGGER_LEVEL || 'info') as LoggerLevel;
   }
   static isStatusExport(): boolean {
     return process.env.STATUS_EXPORT === 'true';
   }
 
   static getStatusExportTimeMs(): number {
-    return parseInt(process.env.STATUS_EXPORT_TIME_MS, 10) || 10 * 1000;
+    return parseInt(process.env.STATUS_EXPORT_TIME_MS!, 10) || 10 * 1000;
   }
 
-  static getStatusFileName(): string {
+  static getStatusFileName(): string | undefined {
     return process.env.STATUS_FILE_NAME;
   }
 
-  static getIslandTracemqHost(): string {
+  static getIslandTracemqHost(): string | undefined {
     return process.env.ISLAND_TRACEMQ_HOST;
   }
 
@@ -74,7 +76,7 @@ export class Environments {
     return (process.env.ISLAND_IGNORE_EVENT_LOG || '').split(',').join('|');
   }
 
-  static getEndpointSessionGroup(): string {
+  static getEndpointSessionGroup(): string | undefined {
     return process.env.ENDPOINT_SESSION_GROUP;
   }
 }

--- a/src/utils/status-collector.ts
+++ b/src/utils/status-collector.ts
@@ -8,9 +8,9 @@ import { logger } from '../utils/logger';
 
 export const STATUS_EXPORT: boolean = Environments.isStatusExport();
 export const STATUS_EXPORT_TIME_MS: number = Environments.getStatusExportTimeMs();
-const STATUS_FILE_NAME: string = Environments.getStatusFileName();
-const HOST_NAME: string = Environments.getHostName();
-const SERVICE_NAME: string = Environments.getServiceName();
+const STATUS_FILE_NAME: string = Environments.getStatusFileName()!;
+const HOST_NAME: string = Environments.getHostName()!;
+const SERVICE_NAME: string = Environments.getServiceName()!;
 const CIRCUIT_BREAK_THRESHOLD: number = 0.2;
 const processUptime: Date = new Date();
 // const SAVE_FILE_NAME: string = '';

--- a/tslint.json
+++ b/tslint.json
@@ -29,7 +29,6 @@
         "no-string-literal": true,
         "no-trailing-whitespace": true,
         "no-unsafe-finally": true,
-        "no-unused-new": true,
         "no-var-keyword": true,
         "no-var-requires": true,
         "object-literal-key-quotes": [


### PR DESCRIPTION
- Bump up lint & typescript version.
- The [type] syntax means tuple.  When define array should use type[]. [typescript spec](https://github.com/Microsoft/TypeScript/blob/master/doc/spec.md#385-tuple-type-literals)
- When something can be null, we should use [Definite Assignment Assertions(syntax "!") ](http://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-7.html).
- process.env type is [string | undefined](https://stackoverflow.com/questions/35666903/typescript-definitions-for-process-env-node-env).
- Remove unused property rpcService.responseConsumerInfo.
