### PR TITLE
feat: ignore SigTerm signal

### DIFF
--- a/src/utils/environments.ts
+++ b/src/utils/environments.ts
@@ -46,6 +46,7 @@ export class Environments {
   static getIslandLoggerLevel(): 'debug' | 'info' | 'notice' | 'warning' | 'error' | 'crit' {
     return process.env.ISLAND_LOGGER_LEVEL || 'info';
   }
+
   static isStatusExport(): boolean {
     return process.env.STATUS_EXPORT === 'true';
   }


### PR DESCRIPTION
It can ignore Signal.

It can be used if the Queue's Consuming needs to continue, such as `gateway-island`.