### PR TITLE
fix: export AdapterOptions

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -21,16 +21,13 @@ export { default as ListenableAdapter } from './adapters/listenable-adapter';
 
 // adapters/impl
 export { default as MessageBrokerAdapter } from './adapters/impl/message-broker-adapter';
-export { default as MongooseAdapter } from './adapters/impl/mongoose-adapter';
-export { default as PushAdapter } from './adapters/impl/push-adapter';
-export { default as RedisConnectionAdapter } from './adapters/impl/redis-connection-adapter';
-export { default as RestifyAdapter } from './adapters/impl/restify-adapter';
-export { default as RPCAdapter } from './adapters/impl/rpc-adapter';
-export { default as SocketIOAdapter } from './adapters/impl/socketio-adapter';
-export {
-  default as RabbitMqAdapter,
-  RabbitMqAdapterOptions
-} from './adapters/impl/rabbitmq-adapter';
+export { default as MongooseAdapter, MongooseAdapterOptions } from './adapters/impl/mongoose-adapter';
+export { default as PushAdapter, PushAdapterOptions } from './adapters/impl/push-adapter';
+export { default as RedisConnectionAdapter, RedisAdapterOptions } from './adapters/impl/redis-connection-adapter';
+export { default as RestifyAdapter, RestifyAdapterOptions } from './adapters/impl/restify-adapter';
+export { default as RPCAdapter, RPCAdapterOptions } from './adapters/impl/rpc-adapter';
+export { default as SocketIOAdapter, SocketIOAdapterOptions } from './adapters/impl/socketio-adapter';
+export { default as RabbitMqAdapter, RabbitMqAdapterOptions } from './adapters/impl/rabbitmq-adapter';
 export { AmqpChannelPoolAdapter } from './adapters/impl/amqp-channel-pool-adapter';
 export { EventAdapter, EventAdapterOptions } from './adapters/impl/event-adapter';
 


### PR DESCRIPTION
https://github.com/spearhead-ea/island/issues/204

Adapter options like `RestifyAdapterOptions` should be exported so that implementation code could define object construction parameter explicitly.

**Specially what I need to know is that ALL adapter options interfaces should be exposed or not.**