### PR TITLE
fix: abnormal console.log for eventPublish

### DIFF
--- a/src/services/event-service.ts
+++ b/src/services/event-service.ts
@@ -152,7 +152,7 @@ export class EventService {
         protocol: 'EVENT',
         correlationId: uuid.v4()
       });
-    logger.debug(`publish ${event.key}`, event.args, options.headers.tattoo);
+    logger.debug(`publish ${event.key}`, JSON.stringify(event.args, null, 2), options.headers.tattoo);
     return Promise.resolve(Bluebird.try(() => new Buffer(JSON.stringify(event.args), 'utf8'))
       .then(content => {
         return this._publish(exchange, event.key, content, options);


### PR DESCRIPTION
# AS-IS
![image](https://user-images.githubusercontent.com/10244446/40645664-fe6c02fc-6361-11e8-81cf-98ce7052a9ae.png)

a problem that `event.args` may not work normally when doing eventPublish. 
corrected to appear normally as shown below


# TO-BE
![image](https://user-images.githubusercontent.com/10244446/40645713-24a31136-6362-11e8-939e-0388cef9846e.png)
