### PR TITLE
refactor: clean dependencies of EventService

### DIFF
--- a/src/spec/event-service.spec.ts
+++ b/src/spec/event-service.spec.ts
@@ -3,7 +3,6 @@ import { EventHookType, EventService } from '../services/event-service';
 import { BaseEvent, DebugEvent, PatternSubscriber } from '../services/event-subscriber';
 import { Environments } from '../utils/environments';
 import { jasmineAsyncAdapter as spec } from '../utils/jasmine-async-support';
-import { TraceLog } from '../utils/tracelog';
 
 import Bluebird = require('bluebird');
 
@@ -110,7 +109,6 @@ describe('EventService', () => {
   afterAll(done => {
     Bluebird.delay(500)
       .then(() => eventService.purge())
-      .then(() => TraceLog.purge())
       .then(() => amqpChannelPool.purge())
       .then(done)
       .catch(done.fail);
@@ -161,7 +159,6 @@ describe('Event-hook', () => {
 
   afterEach(spec(async () => {
     await Bluebird.delay(500);
-    await TraceLog.purge();
     await eventService.purge();
     await amqpChannelPool.purge();
   }));

--- a/src/spec/rpc.spec.ts
+++ b/src/spec/rpc.spec.ts
@@ -19,7 +19,6 @@ import { AbstractEtcError, AbstractFatalError, AbstractLogicError, FatalError, I
 import { jasmineAsyncAdapter as spec } from '../utils/jasmine-async-support';
 import { logger } from '../utils/logger';
 import { collector } from '../utils/status-collector';
-import { TraceLog } from '../utils/tracelog';
 
 Environments.refreshEnvForDebug();
 
@@ -60,7 +59,6 @@ describe('RPC(isolated test)', () => {
     await rpcService.purge();
     await Bluebird.delay(100); // to have time to send ack
     await amqpChannelPool.purge();
-    await TraceLog.purge();
   }));
 
   it('rpc test #1: rpc call', spec(async () => {
@@ -222,7 +220,6 @@ describe('RPC(isolated test)', () => {
     await rpcService.listen();
     await rpcService.purge();
     await amqpChannelPool.purge();
-    await TraceLog.purge();
 
     const url = process.env.RABBITMQ_HOST || 'amqp://rabbitmq:5672';
     await amqpChannelPool.initialize({ url });
@@ -512,7 +509,6 @@ describe('RPC with reviver', async () => {
 
   afterEach(spec(async () => {
     await Bluebird.delay(100);
-    await TraceLog.purge();
     await rpcService.purge();
     await amqpChannelPool.purge();
   }));
@@ -542,7 +538,6 @@ describe('RPC-hook', () => {
 
   afterEach(spec(async () => {
     await Bluebird.delay(100);
-    await TraceLog.purge();
     await rpcService.purge();
     await amqpChannelPool.purge();
   }));


### PR DESCRIPTION
* EventService also doesn't use `TraceLog`

# AS-IS

<img width="972" alt="2018-06-07 6 35 41" src="https://user-images.githubusercontent.com/154198/41095238-7122fdfa-6a83-11e8-9491-158394202e59.png">

# TO-BE

<img width="977" alt="2018-06-07 6 35 47" src="https://user-images.githubusercontent.com/154198/41095245-778e9c9e-6a83-11e8-94b9-25b3e9577295.png">
