### PR TITLE
fix : error code

### DIFF
--- a/src/utils/rpc-response.ts
+++ b/src/utils/rpc-response.ts
@@ -97,7 +97,7 @@ export class RpcResponse {
         result = new AbstractFatalError(islandCode, islandLevel, errorCode, err.reason);
         break;
       default:
-        result = new AbstractEtcError(islandCode, islandLevel, 1, err.reason);
+        result = new AbstractEtcError(islandCode, islandLevel, err.code % 10000 || 1, err.reason);
         result.name = err.name;
     }
 


### PR DESCRIPTION
If not an AbstractError type, use errorCode as err.code

If you do not want to use AbstractError Type, err.code must be less than 1000