### PR TITLE
Hotfix 3.5.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "island",
-  "version": "3.5.4",
+  "version": "3.5.5",
   "description": "A package suite for building microservice using TypeScript.",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/src/utils/rpc-response.ts
+++ b/src/utils/rpc-response.ts
@@ -97,7 +97,7 @@ export class RpcResponse {
         result = new AbstractFatalError(islandCode, islandLevel, errorCode, err.reason);
         break;
       default:
-        result = new AbstractEtcError(islandCode, islandLevel, 1, err.reason);
+        result = new AbstractEtcError(islandCode, islandLevel, err.code, err.reason);
         result.name = err.name;
     }
 


### PR DESCRIPTION
If not an AbstractError type, use errorCode as err.code

If you do not want to use AbstractError Type, err.code must be less than 1000

https://github.com/spearhead-ea/island/pull/240