### PR TITLE
refactor: export ErrorOptions

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -94,6 +94,7 @@ export {
   AbstractExpectedError,
   AbstractFatalError,
   AbstractLogicError,
+  ErrorOptions,
   ErrorLevel,
   ISLAND,
   IslandLevel,


### PR DESCRIPTION
exported `ErrorOptions`. in order to use AbstractError's option