### PR TITLE
fix: a potential zombie by MQ shutdown

### DIFF
--- a/src/services/event-service.ts
+++ b/src/services/event-service.ts
@@ -191,9 +191,9 @@ export class EventService {
     return Promise.resolve(channel.prefetch(prefetchCount || Environments.getEventPrefetch()))
       .then(() => channel.consume(queue, msg => {
         if (!msg) {
-          logger.error(`consume was canceled unexpectedly`);
+          logger.crit(`The event queue is canceled unexpectedly`);
           // TODO: handle unexpected cancel
-          return;
+          return this.shutdown();
         }
 
         if (msg.fields.routingKey === this.fanoutQ) {
@@ -301,5 +301,9 @@ export class EventService {
 
   private sendStatusJsonEvent(data: any) {
     return this.publishEvent(new StatusExport(data));
+  }
+
+  private shutdown() {
+    process.emit('SIGTERM');
   }
 }


### PR DESCRIPTION
* Queues can be deleted by accident
* An island node can be zombie process by the queue deleting
* Fresh dying is better than a half-living

(cherry picked from commit 8c5ce07e7c476532cefb7ebce41e93b82addf9da)