### PR TITLE
feat: correct RPC timeout

### DIFF
--- a/src/services/event-service.ts
+++ b/src/services/event-service.ts
@@ -171,7 +171,7 @@ export class EventService {
     const ns = cls.getNamespace('app');
     return {
       headers: {
-        tattoo: ns.get('RequestTrackId'),
+        tattoo: ns.get('tattoo'),
         from: {
           node: Environments.getHostName(),
           context: ns.get('Context'),
@@ -260,7 +260,7 @@ export class EventService {
     const content = await this.dohook(EventHookType.EVENT, JSON.parse(msg.content.toString('utf8'), reviver));
     const subscribers = this.subscribers.filter(subscriber => subscriber.isRoutingKeyMatched(msg.fields.routingKey));
     const promise = Bluebird.map(subscribers, subscriber => {
-      const clsProperties = _.merge({ RequestTrackId: tattoo, Context: msg.fields.routingKey, Type: 'event' },
+      const clsProperties = _.merge({ tattoo, Context: msg.fields.routingKey, Type: 'event' },
                                     extra);
       return enterScope(clsProperties, () => {
         if (!this.ignoreEventLogRegexp || !msg.fields.routingKey.match(this.ignoreEventLogRegexp)) {

--- a/src/spec/diag.spec.ts
+++ b/src/spec/diag.spec.ts
@@ -107,14 +107,17 @@ describe('RPC Diag', () => {
   let amqpChannelPool;
   let rpcService: RPCService;
   const fileName = 'haha.txt.proc';
-  const oldTimeout = Environments.ISLAND_RPC_WAIT_TIMEOUT_MS;
+  const ISLAND_RPC_EXEC_TIMEOUT_MS = Environments.ISLAND_RPC_EXEC_TIMEOUT_MS;
+  const ISLAND_RPC_REPLY_MARGIN_TIME_MS = Environments.ISLAND_RPC_REPLY_MARGIN_TIME_MS;
 
   beforeAll(spec(async () => {
-    Environments.ISLAND_RPC_WAIT_TIMEOUT_MS = 600;
+    Environments.ISLAND_RPC_EXEC_TIMEOUT_MS = 600;
+    Environments.ISLAND_RPC_REPLY_MARGIN_TIME_MS = 0;
   }));
 
   afterAll(spec(async () => {
-    Environments.ISLAND_RPC_WAIT_TIMEOUT_MS = oldTimeout;
+    Environments.ISLAND_RPC_EXEC_TIMEOUT_MS = ISLAND_RPC_EXEC_TIMEOUT_MS;
+    Environments.ISLAND_RPC_REPLY_MARGIN_TIME_MS = ISLAND_RPC_REPLY_MARGIN_TIME_MS;
   }));
 
   beforeEach(spec(async () => {

--- a/src/spec/rpc-timeout.spec.ts
+++ b/src/spec/rpc-timeout.spec.ts
@@ -1,0 +1,464 @@
+import * as Bluebird from 'bluebird';
+
+import { AmqpChannelPoolService } from '../services/amqp-channel-pool-service';
+import { RpcResponse, RPCService } from '../services/rpc-service';
+import { Environments } from '../utils/environments';
+import { AbstractError, AbstractFatalError, FatalError, ISLAND } from '../utils/error';
+import { jasmineAsyncAdapter as spec } from '../utils/jasmine-async-support';
+
+Environments.refreshEnvForDebug();
+
+describe('RpcResponse', () => {
+  it('should handle malformed response', () => {
+    const malformedJson = '{"result": true, "body": 1';
+    expect(RpcResponse.decode(new Buffer(malformedJson))).toEqual({version: 0, result: false});
+  });
+
+  it('should understand an AbstractError object', () => {
+    const error = new FatalError(ISLAND.ERROR.E0001_ISLET_ALREADY_HAS_BEEN_REGISTERED);
+    const json = JSON.stringify({result: false, body: error});
+    expect(RpcResponse.decode(new Buffer(json)).body).toEqual(jasmine.any(AbstractFatalError));
+  });
+});
+
+describe('RPC(RPC timeout)', () => {
+  const rpcService = new RPCService('haha');
+  const amqpChannelPool = new AmqpChannelPoolService();
+  const ISLAND_RPC_EXEC_TIMEOUT_MS = Environments.ISLAND_RPC_EXEC_TIMEOUT_MS;
+  const ISLAND_RPC_MESSAGE_TTL_MS = Environments.ISLAND_RPC_MESSAGE_TTL_MS;
+  const ISLAND_STATUS_EXPORT = Environments.ISLAND_STATUS_EXPORT;
+  const ISLAND_STATUS_EXPORT_TIME_MS = Environments.ISLAND_STATUS_EXPORT_TIME_MS;
+  const ISLAND_RPC_REPLY_MARGIN_TIME_MS = Environments.ISLAND_RPC_REPLY_MARGIN_TIME_MS;
+
+  beforeAll(spec(async () => {
+    Environments.ISLAND_RPC_EXEC_TIMEOUT_MS = 25000;
+    Environments.ISLAND_RPC_MESSAGE_TTL_MS = 3000;
+    Environments.ISLAND_STATUS_EXPORT = true;
+    Environments.ISLAND_STATUS_EXPORT_TIME_MS = 3000;
+    Environments.ISLAND_RPC_REPLY_MARGIN_TIME_MS = 1000;
+  }));
+
+  afterAll(spec(async () => {
+    Environments.ISLAND_RPC_EXEC_TIMEOUT_MS = ISLAND_RPC_EXEC_TIMEOUT_MS;
+    Environments.ISLAND_RPC_MESSAGE_TTL_MS = ISLAND_RPC_MESSAGE_TTL_MS;
+    Environments.ISLAND_STATUS_EXPORT = ISLAND_STATUS_EXPORT;
+    Environments.ISLAND_STATUS_EXPORT_TIME_MS = ISLAND_STATUS_EXPORT_TIME_MS;
+    Environments.ISLAND_RPC_REPLY_MARGIN_TIME_MS = ISLAND_RPC_REPLY_MARGIN_TIME_MS;
+  }));
+
+  beforeEach(spec(async () => {
+    const url = process.env.RABBITMQ_HOST || 'amqp://rabbitmq:5672';
+    await amqpChannelPool.initialize({ url });
+    await rpcService.initialize(amqpChannelPool);
+  }));
+
+  afterEach(spec(async () => {
+    await rpcService.purge();
+    await Bluebird.delay(100); // to have time to send ack
+    await amqpChannelPool.purge();
+  }));
+
+  it('rpc timeout After ISLAND_RPC_EXEC_TIMEOUT_MS', spec(async () => {
+    await rpcService.register('testMethod', async msg => {
+      expect(msg).toBe('hello');
+      await Bluebird.resolve().delay(1000);
+      return Promise.resolve('world');
+    }, 'rpc');
+    await rpcService.listen();
+    try {
+      await rpcService.invoke<string, string>('testMethod', 'hello', { timeout: 1500 } );
+      fail();
+    } catch (e) {
+      await rpcService.unregisterAll();
+      expect(e instanceof AbstractError).toBeTruthy();
+      expect(e.code).toEqual(10010023);
+      expect(e.name).toEqual('FatalError');
+      expect(e.extra.island).toBe('haha');
+      expect(e.extra.rpcName).toBe('testMethod');
+      expect(e.extra.parent).toBe('testMethod');
+      expect(e.extra.location).toEqual('consume');
+    }
+  }));
+
+  it('rpc timeout After ISLAND_RPC_EXEC_TIMEOUT_MS - ISLAND_RPC_REPLY_MARGIN_TIME_MS', spec(async () => {
+    await rpcService.register('testMethod', async msg => {
+      expect(msg).toBe('hello');
+      await Bluebird.resolve().delay(600);
+      return Promise.resolve('world');
+    }, 'rpc');
+    await rpcService.listen();
+    try {
+      await rpcService.invoke<string, string>('testMethod', 'hello', { timeout: 1500 } );
+      fail();
+    } catch (e) {
+      await rpcService.unregisterAll();
+      expect(e instanceof AbstractError).toBeTruthy();
+      expect(e.code).toEqual(10010023);
+      expect(e.name).toEqual('FatalError');
+      expect(e.extra.island).toBe('haha');
+      expect(e.extra.rpcName).toBe('testMethod');
+      expect(e.extra.parent).toBe('testMethod');
+      expect(e.extra.location).toEqual('consume');
+    }
+  }));
+
+  it('rpc timeout before ISLAND_RPC_EXEC_TIMEOUT_MS - ISLAND_RPC_REPLY_MARGIN_TIME_MS', spec(async () => {
+    await rpcService.register('testMethod', async msg => {
+      expect(msg).toBe('hello');
+      await Bluebird.resolve().delay(400);
+      return Promise.resolve('world');
+    }, 'rpc');
+    await rpcService.listen();
+    try {
+      const res = await rpcService.invoke<string, string>('testMethod', 'hello', { timeout: 1500 } );
+      expect(res).toEqual('world');
+      await rpcService.unregisterAll();
+    } catch (e) {
+      fail();
+    }
+  }));
+
+  it ('rpc timeout occurs in the place where it occurred (invoke) - 3 depth', spec(async () => {
+    await rpcService.register('test', async msg => {
+      expect(msg).toBe('hello');
+      return Promise.resolve(rpcService.invoke<string, string>('depth0', msg));
+    }, 'rpc');
+    await rpcService.register('depth0', msg => {
+      expect(msg).toBe('hello');
+      return Promise.resolve(rpcService.invoke<string, string>('depth1', msg));
+    }, 'rpc');
+    await rpcService.register('depth1', msg => {
+      expect(msg).toBe('hello');
+      // throw error in invoke
+      return Promise.resolve(rpcService.invoke<string, string>('depth2', msg));
+    }, 'rpc');
+    await rpcService.register('depth2', msg => {
+      expect(msg).toBe('hello');
+      return Promise.resolve(rpcService.invoke<string, string>('depth3', msg));
+    }, 'rpc');
+    await rpcService.register('depth3', msg => {
+      expect(msg).toBe('hello');
+      return Promise.resolve('world');
+    }, 'rpc');
+    await rpcService.listen();
+    try {
+      await rpcService.invoke<string, string>('test', 'hello', { timeout: 3900 } );
+      fail();
+    } catch (e) {
+      await rpcService.unregisterAll();
+      expect(e instanceof AbstractError).toBeTruthy();
+      expect(e.code).toEqual(10010023);
+      expect(e.name).toEqual('FatalError');
+      expect(e.extra.island).toBe('haha');
+      expect(e.extra.rpcName).toBe('depth2');
+      expect(e.extra.parent).toBe('test');
+      expect(e.extra.location).toEqual('invoke');
+    }
+  }));
+
+  it ('rpc timeout occurs in the place where it occurred (invoke) - 4 depth', spec(async () => {
+    await rpcService.register('test', async msg => {
+      expect(msg).toBe('hello');
+      return Promise.resolve(rpcService.invoke<string, string>('depth0', msg));
+    }, 'rpc');
+    await rpcService.register('depth0', msg => {
+      expect(msg).toBe('hello');
+      return Promise.resolve(rpcService.invoke<string, string>('depth1', msg));
+    }, 'rpc');
+    await rpcService.register('depth1', msg => {
+      expect(msg).toBe('hello');
+      return Promise.resolve(rpcService.invoke<string, string>('depth2', msg));
+    }, 'rpc');
+    await rpcService.register('depth2', msg => {
+      expect(msg).toBe('hello');
+      // throw error in invoke
+      return Promise.resolve(rpcService.invoke<string, string>('depth3', msg));
+    }, 'rpc');
+    await rpcService.register('depth3', msg => {
+      expect(msg).toBe('hello');
+      return Promise.resolve('world');
+    }, 'rpc');
+    await rpcService.listen();
+    try {
+      await rpcService.invoke<string, string>('test', 'hello', { timeout: 4900 } );
+      fail();
+    } catch (e) {
+      await rpcService.unregisterAll();
+      expect(e instanceof AbstractError).toBeTruthy();
+      expect(e.code).toEqual(10010023);
+      expect(e.name).toEqual('FatalError');
+      expect(e.extra.island).toBe('haha');
+      expect(e.extra.rpcName).toBe('depth3');
+      expect(e.extra.parent).toBe('test');
+      expect(e.extra.location).toEqual('invoke');
+    }
+  }));
+
+  it ('rpc timeout occurs in the place where it occurred (invoke) - 5 depth', spec(async () => {
+    await rpcService.register('test', async msg => {
+      expect(msg).toBe('hello');
+      return Promise.resolve(rpcService.invoke<string, string>('depth0', msg));
+    }, 'rpc');
+    await rpcService.register('depth0', msg => {
+      expect(msg).toBe('hello');
+      return Promise.resolve(rpcService.invoke<string, string>('depth1', msg));
+    }, 'rpc');
+    await rpcService.register('depth1', msg => {
+      expect(msg).toBe('hello');
+      return Promise.resolve(rpcService.invoke<string, string>('depth2', msg));
+    }, 'rpc');
+    await rpcService.register('depth2', async msg => {
+      expect(msg).toBe('hello');
+      // throw error this
+      return Promise.resolve(rpcService.invoke<string, string>('depth3', msg));
+    }, 'rpc');
+    await rpcService.register('depth3', msg => {
+      expect(msg).toBe('hello');
+      return Promise.resolve('world');
+    }, 'rpc');
+    await rpcService.listen();
+    try {
+      await rpcService.invoke<string, string>('test', 'hello', { timeout: 4900 } );
+      fail();
+    } catch (e) {
+      await rpcService.unregisterAll();
+      expect(e instanceof AbstractError).toBeTruthy();
+      expect(e.code).toEqual(10010023);
+      expect(e.name).toEqual('FatalError');
+      expect(e.extra.island).toBe('haha');
+      expect(e.extra.rpcName).toBe('depth3');
+      expect(e.extra.parent).toBe('test');
+      expect(e.extra.location).toBe('invoke');
+    }
+  }));
+
+  it ('rpc timeout occurs in the place where it occurred (consume) - 3 depth', spec(async () => {
+    await rpcService.register('test', async msg => {
+      expect(msg).toBe('hello');
+      return Promise.resolve(rpcService.invoke<string, string>('depth0', msg));
+    }, 'rpc');
+    await rpcService.register('depth0', msg => {
+      expect(msg).toBe('hello');
+      return Promise.resolve(rpcService.invoke<string, string>('depth1', msg));
+    }, 'rpc');
+    await rpcService.register('depth1', async msg => {
+      expect(msg).toBe('hello');
+      // throw error in this
+      await Bluebird.resolve().delay(900);
+      return Promise.resolve(rpcService.invoke<string, string>('depth2', msg));
+    }, 'rpc');
+    await rpcService.register('depth2', msg => {
+      expect(msg).toBe('hello');
+      return Promise.resolve(rpcService.invoke<string, string>('depth3', msg));
+    }, 'rpc');
+    await rpcService.register('depth3', msg => {
+      expect(msg).toBe('hello');
+      return Promise.resolve('world');
+    }, 'rpc');
+    await rpcService.listen();
+    try {
+      await rpcService.invoke<string, string>('test', 'hello', { timeout: 3900 } );
+      fail();
+    } catch (e) {
+      await rpcService.unregisterAll();
+      expect(e instanceof AbstractError).toBeTruthy();
+      expect(e.code).toEqual(10010023);
+      expect(e.name).toEqual('FatalError');
+      expect(e.extra.island).toBe('haha');
+      expect(e.extra.rpcName).toBe('depth1');
+      expect(e.extra.parent).toBe('test');
+      expect(e.extra.location).toEqual('consume');
+    }
+  }));
+
+  it ('rpc timeout occurs in the place where it occurred (consume) - 4 depth', spec(async () => {
+    await rpcService.register('test', msg => {
+      expect(msg).toBe('hello');
+      return Promise.resolve(rpcService.invoke<string, string>('depth0', msg));
+    }, 'rpc');
+    await rpcService.register('depth0', msg => {
+      expect(msg).toBe('hello');
+      return Promise.resolve(rpcService.invoke<string, string>('depth1', msg));
+    }, 'rpc');
+    await rpcService.register('depth1', msg => {
+      expect(msg).toBe('hello');
+      return Promise.resolve(rpcService.invoke<string, string>('depth2', msg));
+    }, 'rpc');
+    await rpcService.register('depth2', async msg => {
+      expect(msg).toBe('hello');
+      // throw error in this
+      await Bluebird.resolve().delay(900);
+      return Promise.resolve(rpcService.invoke<string, string>('depth3', msg));
+    }, 'rpc');
+    await rpcService.register('depth3', msg => {
+      expect(msg).toBe('hello');
+      return Promise.resolve('world');
+    }, 'rpc');
+    await rpcService.listen();
+    try {
+      await rpcService.invoke<string, string>('test', 'hello', { timeout: 4900 } );
+      fail();
+    } catch (e) {
+      await rpcService.unregisterAll();
+      expect(e instanceof AbstractError).toBeTruthy();
+      expect(e.code).toEqual(10010023);
+      expect(e.name).toEqual('FatalError');
+      expect(e.extra.island).toBe('haha');
+      expect(e.extra.rpcName).toBe('depth2');
+      expect(e.extra.parent).toBe('test');
+      expect(e.extra.location).toEqual('consume');
+    }
+  }));
+
+  it ('replay wait time is recovered, when invoke is complete.', spec(async () => {
+    await rpcService.register('test', async msg => {
+      expect(msg).toBe('hello');
+      await Promise.resolve(rpcService.invoke<string, string>('rpc1', msg));
+      await Promise.resolve(rpcService.invoke<string, string>('rpc2', msg));
+      return Promise.resolve(rpcService.invoke<string, string>('rpc3', msg));
+    }, 'rpc');
+    await rpcService.register('rpc1', msg => {
+      expect(msg).toBe('hello');
+      return Promise.resolve(rpcService.invoke<string, string>('rpc1-1', msg));
+    }, 'rpc');
+    await rpcService.register('rpc1-1', msg => {
+      expect(msg).toBe('hello');
+      return Promise.resolve('rpc1 hello');
+    }, 'rpc');
+    await rpcService.register('rpc2', msg => {
+      expect(msg).toBe('hello');
+      return Promise.resolve(rpcService.invoke<string, string>('rpc2-1', msg));
+    }, 'rpc');
+    await rpcService.register('rpc2-1', msg => {
+      expect(msg).toBe('hello');
+      return Promise.resolve('rpc2 hello');
+    }, 'rpc');
+    await rpcService.register('rpc3', msg => {
+      expect(msg).toBe('hello');
+      return Promise.resolve('world');
+    }, 'rpc');
+    await rpcService.listen();
+    try {
+      const res = await rpcService.invoke<string, string>('test', 'hello', { timeout: 3900 } );
+      expect(res).toEqual('world');
+      await rpcService.unregisterAll();
+    } catch (e) {
+      fail();
+    }
+  }));
+
+  it ('reply wait time is recovered, when invoke is complete. - timeout case', spec(async () => {
+    await rpcService.register('test', async msg => {
+      expect(msg).toBe('hello');
+      const res1 = await Promise.resolve(rpcService.invoke<string, string>('rpc1', msg));
+      expect(res1).toBe('rpc1 hello');
+      await Promise.resolve(rpcService.invoke<string, string>('rpc2', msg));
+      return Promise.resolve(rpcService.invoke<string, string>('rpc3', msg));
+    }, 'rpc');
+    await rpcService.register('rpc1', msg => {
+      expect(msg).toBe('hello');
+      return Promise.resolve('rpc1 hello');
+    }, 'rpc');
+    await rpcService.register('rpc2', async msg => {
+      return Promise.resolve(rpcService.invoke<string, string>('rpc2-1', msg));
+    }, 'rpc');
+    await rpcService.register('rpc2-1', async msg => {
+      return Promise.resolve(rpcService.invoke<string, string>('rpc2-2', msg));
+    }, 'rpc');
+    await rpcService.register('rpc2-2', async msg => {
+      expect(msg).toBe('hello');
+      await Bluebird.resolve().delay(900);
+      return Promise.resolve('rpc2 hello');
+    }, 'rpc');
+    await rpcService.register('rpc3', msg => {
+      expect(msg).toBe('hello');
+      return Promise.resolve('world');
+    }, 'rpc');
+    await rpcService.listen();
+    try {
+      await rpcService.invoke<string, string>('test', 'hello', { timeout: 4900 } );
+      fail();
+    } catch (e) {
+      await rpcService.unregisterAll();
+      expect(e instanceof AbstractError).toBeTruthy();
+      expect(e.code).toEqual(10010023);
+      expect(e.name).toEqual('FatalError');
+      expect(e.extra.island).toBe('haha');
+      expect(e.extra.rpcName).toBe('rpc2-2');
+      expect(e.extra.parent).toBe('test');
+      expect(e.extra.location).toEqual('consume');
+    }
+  }));
+
+  it ('Small values ​​are used - child', spec(async () => {
+    await rpcService.register('test', async msg => {
+      expect(msg).toBe('hello');
+      const res1 = await Promise.resolve(rpcService.invoke<string, string>('rpc1', msg));
+      expect(res1).toBe('rpc1 hello');
+      await Promise.resolve(rpcService.invoke<string, string>('rpc2', msg, {timeout: 1500}));
+      return Promise.resolve(rpcService.invoke<string, string>('rpc3', msg));
+    }, 'rpc');
+    await rpcService.register('rpc1', msg => {
+      expect(msg).toBe('hello');
+      return Promise.resolve('rpc1 hello');
+    }, 'rpc');
+    await rpcService.register('rpc2', async msg => {
+      await Bluebird.resolve().delay(900);
+      return Promise.resolve('rpc2 hello');
+    }, 'rpc');
+    await rpcService.register('rpc3', msg => {
+      expect(msg).toBe('hello');
+      return Promise.resolve('world');
+    }, 'rpc');
+    await rpcService.listen();
+    try {
+      await rpcService.invoke<string, string>('test', 'hello', { timeout: 10000 } );
+      fail();
+    } catch (e) {
+      await rpcService.unregisterAll();
+      expect(e instanceof AbstractError).toBeTruthy();
+      expect(e.code).toEqual(10010023);
+      expect(e.name).toEqual('FatalError');
+      expect(e.extra.island).toBe('haha');
+      expect(e.extra.rpcName).toBe('rpc2');
+      expect(e.extra.parent).toBe('test');
+      expect(e.extra.location).toEqual('consume');
+    }
+  }));
+
+  it ('Small values ​​are used - parent', spec(async () => {
+    await rpcService.register('test', async msg => {
+      expect(msg).toBe('hello');
+      const res1 = await Promise.resolve(rpcService.invoke<string, string>('rpc1', msg));
+      expect(res1).toBe('rpc1 hello');
+      await Promise.resolve(rpcService.invoke<string, string>('rpc2', msg, {timeout: 10000}));
+      return Promise.resolve(rpcService.invoke<string, string>('rpc3', msg));
+    }, 'rpc');
+    await rpcService.register('rpc1', msg => {
+      expect(msg).toBe('hello');
+      return Promise.resolve('rpc1 hello');
+    }, 'rpc');
+    await rpcService.register('rpc2', async msg => {
+      await Bluebird.resolve().delay(1000);
+      return Promise.resolve('rpc2 hello');
+    }, 'rpc');
+    await rpcService.register('rpc3', msg => {
+      expect(msg).toBe('hello');
+      return Promise.resolve('world');
+    }, 'rpc');
+    await rpcService.listen();
+    try {
+      await rpcService.invoke<string, string>('test', 'hello', { timeout: 3000 } );
+      fail();
+    } catch (e) {
+      await rpcService.unregisterAll();
+      expect(e instanceof AbstractError).toBeTruthy();
+      expect(e.code).toEqual(10010023);
+      expect(e.name).toEqual('FatalError');
+      expect(e.extra.island).toBe('haha');
+      expect(e.extra.rpcName).toBe('rpc2');
+      expect(e.extra.parent).toBe('test');
+      expect(e.extra.location).toEqual('consume');
+    }
+  }));
+});

--- a/src/utils/env-loader.ts
+++ b/src/utils/env-loader.ts
@@ -48,8 +48,6 @@ const defaultSchemaStorage = new SchemaStorage();
 function makeDecorator(optionalSchema?: any) {
   return (object: Object, propertyName: string) => {
     const metadata = Reflect.getMetadata('design:type', object, propertyName);
-    // console.log(`${propertyName} props: ${Object.getOwnPropertyNames(metadata)}`);
-
     let type = '';
     switch (metadata.name) {
       case 'String':

--- a/src/utils/environments.ts
+++ b/src/utils/environments.ts
@@ -39,19 +39,15 @@ export class IslandEnvironments {
   @env()
   public ISLAND_RPC_EXEC_TIMEOUT_MS: number = 0;
 
-  // Timeout during RPC call
+  // RPC Message TTL
   @env()
-  public ISLAND_RPC_WAIT_TIMEOUT: string = '60s';
-  // deprecated
-  @env()
-  public ISLAND_RPC_WAIT_TIMEOUT_MS: number = 0;
+  public ISLAND_RPC_MESSAGE_TTL: string = '60s';
+  public ISLAND_RPC_MESSAGE_TTL_MS: number;
 
-  // Time to load service
+  // Reply addition time By RPC Depth
   @env()
-  public ISLAND_SERVICE_LOAD_TIME: string = '60s';
-  // deprecated
-  @env()
-  public ISLAND_SERVICE_LOAD_TIME_MS: number = 0;
+  public ISLAND_RPC_REPLY_MARGIN_TIME: string = '1s';
+  public ISLAND_RPC_REPLY_MARGIN_TIME_MS: number;
 
   // Log level for logger
   @env({ eq: ['debug', 'info', 'notice', 'warning', 'error', 'crit'] })
@@ -177,12 +173,7 @@ export class IslandEnvironments {
     this.ISLAND_RPC_EXEC_TIMEOUT_MS = this.ISLAND_RPC_EXEC_TIMEOUT_MS === 0
                                       ? ms(this.ISLAND_RPC_EXEC_TIMEOUT)
                                       : this.ISLAND_RPC_EXEC_TIMEOUT_MS;
-    this.ISLAND_RPC_WAIT_TIMEOUT_MS = this.ISLAND_RPC_WAIT_TIMEOUT_MS === 0
-                                      ? ms(this.ISLAND_RPC_EXEC_TIMEOUT)
-                                      : this.ISLAND_RPC_WAIT_TIMEOUT_MS;
-    this.ISLAND_SERVICE_LOAD_TIME_MS = this.ISLAND_SERVICE_LOAD_TIME_MS === 0
-                                       ? ms(this.ISLAND_SERVICE_LOAD_TIME)
-                                       : this.ISLAND_SERVICE_LOAD_TIME_MS;
+    this.ISLAND_RPC_MESSAGE_TTL_MS = ms(this.ISLAND_RPC_MESSAGE_TTL);
     this.ISLAND_STATUS_EXPORT_TIME_MS = this.ISLAND_STATUS_EXPORT_TIME_MS === 0
                                         ? ms(this.ISLAND_STATUS_EXPORT_TIME)
                                         : this.ISLAND_STATUS_EXPORT_TIME_MS;
@@ -192,6 +183,7 @@ export class IslandEnvironments {
     this.ISLAND_FLOWMODE_DELAY = this.ISLAND_FLOWMODE_DELAY === 0
                                  ? ms(this.ISLAND_FLOWMODE_DELAY_TIME)
                                  : this.ISLAND_FLOWMODE_DELAY;
+    this.ISLAND_RPC_REPLY_MARGIN_TIME_MS = ms(this.ISLAND_RPC_REPLY_MARGIN_TIME);
     LoadEnv(this);
   }
 
@@ -221,14 +213,6 @@ export class IslandEnvironments {
 
   public getIslandRpcExecTimeoutMs(): number {
     return this.ISLAND_RPC_EXEC_TIMEOUT_MS;
-  }
-
-  public getIslandRpcWaitTimeoutMs(): number {
-    return this.ISLAND_RPC_WAIT_TIMEOUT_MS;
-  }
-
-  public getIslandServiceLoadTimeMs(): number {
-    return this.ISLAND_SERVICE_LOAD_TIME_MS;
   }
 
   public isIslandRpcResNoack(): boolean {

--- a/src/utils/error.ts
+++ b/src/utils/error.ts
@@ -93,6 +93,7 @@ export class AbstractError extends Error {
   public statusCode: number;
   public stack: any;
   public extra: any;
+  public tattoo: any;
 
   constructor(islandCode: number,
               islandLevel: IslandLevel,

--- a/src/utils/route-logger.ts
+++ b/src/utils/route-logger.ts
@@ -65,7 +65,6 @@ export class RouteLogger {
   }
 
   static replaceLogs(clsNameSpace, routeLogs: RouteLog[]): void {
-    // console.log('replaceLogs', routeLogs);
     if (!RouteLogger.isEnabled()) return;
 
     const ns = cls.getNamespace(clsNameSpace);


### PR DESCRIPTION
fix: Incorrect RPC timeout

**How to use**
Added `timeout` with RPC Invoke option.
default timeout is ISLAND_RPC_EXEC_TIMEOUT (25s)
```
await rpcService.invoke(RPCName, Argument, { timeout?: ms } );
```

**Changes**
- Environments have been removed
  `ISLAND_RPC_WAIT_TIMEOUT`
  `ISLAND_RPC_WAIT_TIMEOUT_MS`
  `ISLAND_SERVICE_LOAD_TIME`
  `ISLAND_SERVICE_LOAD_TIME_MS`
- Environments have been added
  `ISLAND_RPC_MESSAGE_TTL` : (60s) The time to be cleared after the RPC Message is used
  `ISLAND_RPC_REPLY_MARGIN_TIME` :  (1s) This is the appended time for taking occurred timeout error in consume at invoke
- Timeout Error has changed.
   AbstractEtcError  -> AbstractError
   error.code : 10020001 -> 10010023
   error.name: TimeoutError -> FatalError
   error.extra has rpcName, parent, waitTime, and location.
     + rpcName: string : occurred RPC name
     + parent: string : Top-level parent RPC name
     + waitTime: allowed Exec Time
     + location: 'consume' | 'invoke' : occurred location

**Other changes**
- It keeps the error code even if it is an unknown error

**Description**

RPC timeout was only considered in only one RPC.
If RPC is called in RPC, timeout will work abnormally.

The concept of `REPLY_MARGIN_TIME` has been added.
`REPLY_MARGIN_TIME` is time for ensuring communication cost per RPC step.
`REPLY_MARGIN_TIME` will be restored when invoke completes.
```
invoke('A', {}, {timeout: 10s});
==========================
invoke timeout 10s, REPLY_MARGIN_TIME1s
Consume A : REPLY_MARGIN_TIME1s => timeout = 9s
A --> B : timeout = 9s(timeout) - 1s(slacTime)  => 8s
A <-- B : execution time 2s 
A --> C : timeout = 9s(timeout) - 2s(executionTime) - 1s(REPLY_MARGIN_TIME) => 6s
C --> D : timeout = 6s(timeout) - 1s(REPLY_MARGIN_TIME) => 5s
C <-- D : execution time 3s => timeout of C = 6s - 3s = 3s
A <-- C : execution time  1s
// If it execution for more than 3 seconds in here, timeout
Time remaining of A : 
   10s (timeout)
-   1s (REPLY_MARGIN_TIME)
-   6s (2s (execution time  of B) + 4s (execution time of C, 1s(C) +3s(D)))
= 3s
==========================
The total run time for RPC A is 6s
```

**Case**
```
// test RPC expects to run for up to 1 minute
invoke(RPC1 , '', { timeout: 60000 });
==========================
#  RPC1
// RPC1 can run for up to 59s except for REPLY_MARGIN_TIME(1000).
// Consume time is also excluded ( @ConsumeRPC1 )
// timeout 60000 - REPLY_MARGIN_TIME(1000) - Consume Time(@ConsumeTest ) = 59000 - @ConsumeRPC1 
...
// RPC1 calls RPC2. timeout is inherited.
invoke(RPC2, '');
==========================
# RPC2
// RPC1 timeout is 59000 - @ConsumeRPC1 
// Consume time is also excluded ( @ConsumeRPC2 )
// timeout RPC1 timeout - REPLY_MARGIN_TIME(1000) - Consume Time(@ConsumeRPC2 ) = 58000 - @ConsumeRPC2
return
```
