### PR TITLE
feat: common system events

### DIFF
--- a/src/controllers/endpoint-decorator.ts
+++ b/src/controllers/endpoint-decorator.ts
@@ -1,6 +1,7 @@
 import * as _ from 'lodash';
 import { Environments } from '../utils/environments';
 import { FatalError, ISLAND } from '../utils/error';
+import { information } from '../utils/information';
 
 export enum EnsureOptions {
   TOKEN = 1,
@@ -832,6 +833,7 @@ export function endpointController(registerer?: {
       if (_listen && !_listen.isRegister) {
         // tslint:disable-next-line
         this._server.listen = async function () {
+          information.saveEndpoint();
           if (registerer) {
             await registerer.saveEndpoint();
           }
@@ -851,6 +853,7 @@ export function endpointController(registerer?: {
         if (Environments.getEndpointSessionGroup() && !v.options.sessionGroup)
           v.options.sessionGroup = Environments.getEndpointSessionGroup();
         return this.server.register(v.name, v.handler.bind(this), 'endpoint').then(() => {
+          information.registerEndpoint(v.name, v.options);
           return registerer && registerer.registerEndpoint(v.name, v.options || {}) || Promise.resolve();
         }).catch(e => {
           throw new FatalError(ISLAND.ERROR.E0028_CONSUL_ERROR, e.message);

--- a/src/utils/environments.ts
+++ b/src/utils/environments.ts
@@ -163,6 +163,8 @@ export class IslandEnvironments {
   @env()
   public ISLAND_FLOWMODE_DELAY: number = 0;
 
+  public VERSION: string = 'unknown';
+
   // @env()
   // public ISLAND_IGNORE_EVENT_LOG: string = '';
 
@@ -184,6 +186,8 @@ export class IslandEnvironments {
                                  ? ms(this.ISLAND_FLOWMODE_DELAY_TIME)
                                  : this.ISLAND_FLOWMODE_DELAY;
     this.ISLAND_RPC_REPLY_MARGIN_TIME_MS = ms(this.ISLAND_RPC_REPLY_MARGIN_TIME);
+
+    this.setIslandInfoFromPackageJson();
     LoadEnv(this);
   }
 
@@ -195,8 +199,12 @@ export class IslandEnvironments {
     return this.ISLAND_HOST_NAME;
   }
 
-  public getServiceName(): string | undefined {
+  public getServiceName(): string {
     return this.ISLAND_SERVICE_NAME;
+  }
+
+  public getIslandVersion(): string {
+    return this.VERSION;
   }
 
   public getEventPrefetch(): number {
@@ -285,6 +293,26 @@ export class IslandEnvironments {
 
   public getFlowModeDelay(): number {
     return this.ISLAND_FLOWMODE_DELAY;
+  }
+
+  private setIslandInfoFromPackageJson(): void {
+    const execPath = this.getExecPath();
+    if (!execPath) return;
+    try {
+      const pkg = require(`${execPath}package.json`);
+      this.VERSION = pkg.version || this.VERSION;
+      this.ISLAND_SERVICE_NAME = pkg.name || this.ISLAND_SERVICE_NAME;
+    } catch (e) {
+      console.info('did not get info From package.json');
+    }
+  }
+
+  private getExecPath() {
+    const dirName = __dirname;
+    if (dirName.indexOf('node_modules/') > -1)
+      return dirName.substr(0, dirName.indexOf('node_modules/'));
+    if (dirName.indexOf('island/') > -1)
+      return dirName.substr(0, dirName.indexOf('island/') + 7);
   }
 }
 

--- a/src/utils/information.ts
+++ b/src/utils/information.ts
@@ -1,0 +1,64 @@
+import * as Crypto from 'crypto';
+import * as _ from 'lodash';
+import { EndpointOptions } from '../controllers/endpoint-decorator';
+import { Environments } from './environments';
+import { Events } from './event';
+
+export interface Endpoints {
+  [name: string]: EndpointOptions;
+}
+
+export class Information {
+  public static getInstance(): Information {
+    Information._instance = Information._instance || new Information();
+    return Information._instance;
+  }
+
+  private static _instance: Information;
+  private SERVICE_NAME: string;
+  private VERSION: string;
+  private SYNCED: boolean = false;
+  private ENDPOINTS: Endpoints = {};
+  private ENDPOINT_CHECKSUM: string;
+
+  constructor() {
+    this.VERSION = Environments.getIslandVersion();
+    this.SERVICE_NAME = Environments.getServiceName();
+  }
+
+  isSynced(): boolean {
+    return this.SYNCED;
+  }
+
+  registerEndpoint(name: string, options: EndpointOptions) {
+    this.ENDPOINTS[name] = options;
+  }
+
+  saveEndpoint() {
+    this.ENDPOINT_CHECKSUM = this.checksum(this.ENDPOINTS);
+    this.SYNCED = true;
+  }
+
+  getSystemInfo(): Events.Arguments.SystemInfo {
+    return {
+      name: this.SERVICE_NAME,
+      version: this.VERSION,
+      checksum: this.SYNCED && this.ENDPOINT_CHECKSUM || ''
+    };
+  }
+
+  getEndpoints(): Events.Arguments.SystemEndpointInfo {
+    return {
+      name: this.SERVICE_NAME,
+      version: this.VERSION,
+      checksum: this.SYNCED && this.ENDPOINT_CHECKSUM || '',
+      endpoints: this.SYNCED && this.ENDPOINTS || {}
+    };
+  }
+
+  private checksum(obj: any, algorithm?: string, encoding?: Crypto.HexBase64Latin1Encoding): string {
+    const str = JSON.stringify((_(obj).toPairs().sortBy(0) as any).fromPairs().value());
+    return Crypto.createHash(algorithm || 'md5').update(str, 'utf8').digest(encoding || 'hex');
+  }
+}
+export const information = Information.getInstance();


### PR DESCRIPTION
Pre-work to not use island-keeper(consul).
Add a common Event.


1. When **SystemHealthCheck** is publish, a **SystemInfo** is raised
2. added and changed known by **SystemInfo**
3. if added or changed, you can publishEvent **SystemEndpointCheck** 
4. When **SystemEndpointCheck** is publish, a **SystemEndpointInfo** is raised
5. you can sync endpoints by **SystemEndpointInfo** 

| Event Name        | Event               | Caller                  | Callee | Trigger |
| ----------------- | ------------------- | ----------------------- | ------ |-------- |
| SystemHealthCheck | System.health.check | gateway-island | island.js | SystemInfo |
| SystemInfo        | System.info.checked | island.js | gateway-island | SystemEndpointCheck |
| SystemEndpointCheck | System.endpoint.check | gateway-island| island.js | SystemEndpointInfo |
| SystemEndpointInfo  | System.endpoint.checked | island.js | gateway-island |  |

**environments** `ISLAND_SERVICE_NAME` and `VERSION` refer to the package.json of xxx-island.