### PR TITLE
feat: ISLAND_MAX_INITIALIZATION_TIME

### DIFF
--- a/src/utils/environments.ts
+++ b/src/utils/environments.ts
@@ -162,6 +162,9 @@ export class IslandEnvironments {
   // deprecated
   @env()
   public ISLAND_FLOWMODE_DELAY: number = 0;
+  @env()
+  public ISLAND_MAX_INITIALIZATION_TIME: string = '1m';
+  public ISLAND_MAX_INITIALIZATION_TIME_MS: number = 0;
 
   public VERSION: string = 'unknown';
 
@@ -186,6 +189,7 @@ export class IslandEnvironments {
                                  ? ms(this.ISLAND_FLOWMODE_DELAY_TIME)
                                  : this.ISLAND_FLOWMODE_DELAY;
     this.ISLAND_RPC_REPLY_MARGIN_TIME_MS = ms(this.ISLAND_RPC_REPLY_MARGIN_TIME);
+    this.ISLAND_MAX_INITIALIZATION_TIME_MS = ms(this.ISLAND_MAX_INITIALIZATION_TIME);
 
     this.setIslandInfoFromPackageJson();
     LoadEnv(this);


### PR DESCRIPTION
If the initialization fails for more than ISLAND_MAX_INITIALIZATION_TIME_MS,
it will be terminated.

ISLAND_MAX_INITIALIZATION_TIME_MS is default 1m.

```
async function sleep(value, millis) {
  return new Promise(function (resolve, reject) {
    setTimeout(function () { resolve(value); }, millis);
  });
}
async function timeout(value, millis) {
  return new Promise(function (resolve, reject) {
    setTimeout(function () { reject(value); }, millis);
  });
}

Promise.all([ sleep(1, 0), sleep(2, 1000), sleep(3, 2000) ]).then(res => console.log('result : ' + res)).catch(e => console.log('error : ' + e));
> result : 1,2,3

Promise.race([ Promise.all([ sleep(1, 0), sleep(2, 1000), sleep(3, 2000) ]),
               timeout('timeout', 1500) ]).then(res => console.log('result : ' + res)).catch(e => console.log('error : ' + e));
> error : timeout

Promise.race([ Promise.all([ sleep(1, 0), sleep(2, 1000) ]),
               timeout('timeout', 1500) ]).then(res => console.log('result : ' + res)).catch(e => console.log('error : ' + e));
> result : 1,2
```