### PR TITLE
refactor: modified purging loacation for rpcService

### DIFF
--- a/src/services/event-service.ts
+++ b/src/services/event-service.ts
@@ -1,9 +1,9 @@
 import { cls } from 'island-loggers';
 
-import { Event, BaseEvent } from 'island-types';
 import * as amqp from 'amqplib';
 import * as Bluebird from 'bluebird';
 import * as fs from 'fs';
+import { BaseEvent, Event } from 'island-types';
 import * as _ from 'lodash';
 import * as uuid from 'uuid';
 
@@ -103,7 +103,8 @@ export class EventService {
   }
 
   async purge(): Promise<any> {
-    fs.unlinkSync('./event.proc');
+    try { fs.unlinkSync('./event.proc'); } catch (_e) {}
+    logger.info('stop serving event');
     this.hooks = {};
     if (!this.consumerInfosMap) return Promise.resolve();
     await Promise.all(_.map(this.consumerInfosMap, (consumerInfo: IEventConsumerInfo) => {


### PR DESCRIPTION
# A description of the issue
   * docker stop
   * sends SIGTERM to the process
   * Islet.js receives SIGTERM
   * Islet.js destroy all adapters
   * Purge the service each adapter is adaptee
   * Typical ListenableAdapters such as RPC and Event do not terminate immediately in the purge situation but finish the handler in process.
   * At this time RPC calls `purging ()` before `channel.ack ()`, so channelPool is `purge()` before `rpc.purging()`


![image](https://user-images.githubusercontent.com/10244446/46859732-868b2300-ce49-11e8-801d-022ef8dc10bd.png)

To solve this, moved the position of `purging()` after `channel.ack()`.