### PR TITLE
fix timed out RPC uuid test failure

### DIFF
--- a/src/spec/rpc.spec.ts
+++ b/src/spec/rpc.spec.ts
@@ -288,8 +288,8 @@ describe('RPC(isolated test)', () => {
   }));
 
   it('should ensure the uuid of the error raised by the RPC which has been timed out', spec(async () => {
-    await rpcService.register('out', () => {
-      return rpcService.invoke('unmethod', 'arg');
+    await rpcService.register('out', async () => {
+      return await Bluebird.delay(1000);
     }, 'rpc');
     await rpcService.listen();
     try {


### PR DESCRIPTION
## Background
Test case "should ensure the uuid of the error raised by the RPC which has been timed out" fails randomly. It may be occured 3 or 4 times on 10 times try. 

## Cause
That test case tests whether uuid is registered when RPC time out occur. To regenerate time out, test case invokes unregistered RPC. Invoking unregistered RPC make channel close. 

```
await rpcService.register('out', async () => {
  return rpcService.invoke('unmethod', 'arg'); // way to make time out
}, 'rpc');
```

When time out exception is thrown rpcService send ack to channel which is already closed.
```
rpc-service.ts
try {
  await handler(msg);
  if (!noAck) channel.ack(msg);
} catch (error) {
  // ...
  // Here, channel may be closed already randomly when 404 error occur by above code
   if (!noAck && msg) channel.ack(msg);  
} finally {
   // ...
}
```

## Resolve
This test cases intention is testing in time out situation. So I changed way to regenerate time out situation from invoking unregistered RPC to just wait more than time out value.

```
return await Bluebird.delay(1000); // just make timed out
```