### PR TITLE
fix: wrong event name & change arrow function

### DIFF
--- a/src/utils/event.ts
+++ b/src/utils/event.ts
@@ -136,13 +136,13 @@ export const DEFAULT_SUBSCRIPTIONS: EventSubscription<Event<any>, any>[] = [{
     options: {everyNodeListen: true}
   }, {
     eventClass: Events.SystemHealthCheck,
-    handler: async (event: Events.SystemHealthCheck) => {
+    async handler(event: Events.SystemHealthCheck) {
       if (!information.isSynced()) return;
       this.publishEvent(new Events.SystemInfo(information.getSystemInfo()));
     }
   }, {
-    eventClass: Events.SystemHealthCheck,
-    handler: async (event: Events.SystemEndpointCheck) => {
+    eventClass: Events.SystemEndpointCheck,
+    async handler(event: Events.SystemEndpointCheck) {
       const info = information.getSystemInfo();
       if (event.args.name !== info.name || !information.isSynced()) return;
       this.publishEvent(new Events.SystemEndpointInfo(information.getEndpoints()));


### PR DESCRIPTION
# Fixed Context
1.  wrong event class
```[--------|11:09:35|d] subscribe event : system.health.check
[5] =================================== [island] SystemEndpointCheck  SystemHealthCheck {
 key: 'system.health.check',
 args: {},
 publishedAt: 2018-10-22T02:09:34.996Z }```
2. can't not use publishEvent on a island Default Subscirbe event function
```[--------|11:09:40|e] error on handling event {"extra":{"args":{},"event":"system.health.check","island":"gateway-island"}}
[--------|11:09:40|d] publish log.error {
 "message": "this.publishEvent is not a function",
 "params": {},...```
# Changed context
1. typo event name for SystemEndpointCheck (`SystemHealthCheck` -> `SystemEndpointCheck`)
2. changed `arrow function` -> `function` according to `this`
the second changed contecxt here is explain [this stack over flow](https://stackoverflow.com/questions/34361379/arrow-function-vs-function-declaration-expressions-are-they-equivalent-exch)