### PR TITLE
feat: Endpoint Conflict

### DIFF
--- a/src/utils/event.ts
+++ b/src/utils/event.ts
@@ -1,8 +1,9 @@
 import * as fs from 'fs';
 import { Loggers } from 'island-loggers';
 import { BaseEvent, Event } from 'island-types';
-
+import * as _ from 'lodash';
 import { EventHandler, SubscriptionOptions } from '../services/event-subscriber';
+import { logger } from '../utils/logger';
 import { Endpoints, information } from './information';
 import { collector } from './status-collector';
 
@@ -51,6 +52,12 @@ export namespace Events {
 
     export interface SystemEndpointCheck {
       name: string;
+    }
+
+    export interface SystemEndpointConflict {
+      infos: { name: string;
+               endpoint: string;
+             }[];
     }
   }
 
@@ -101,6 +108,12 @@ export namespace Events {
       super('system.endpoint.check', args);
     }
   }
+
+  export class SystemEndpointConflict extends BaseEvent<Arguments.SystemEndpointConflict> {
+    constructor(args: Arguments.SystemEndpointConflict) {
+      super('system.endpoint.conflict', args);
+    }
+  }
 }
 
 export const DEFAULT_SUBSCRIPTIONS: EventSubscription<Event<any>, any>[] = [{
@@ -146,6 +159,15 @@ export const DEFAULT_SUBSCRIPTIONS: EventSubscription<Event<any>, any>[] = [{
       const info = information.getSystemInfo();
       if (event.args.name !== info.name || !information.isSynced()) return;
       this.publishEvent(new Events.SystemEndpointInfo(information.getEndpoints()));
+    }
+  }, {
+    eventClass: Events.SystemEndpointConflict,
+    async handler(event: Events.SystemEndpointConflict) {
+      const info = information.getSystemInfo();
+      if (!_.find(event.args.infos, o => o.name === info.name)) return;
+      event.args.infos.forEach(o => {
+        logger.warning(`Endpoint Conflict > island: ${o.name} endpoint: ${o.endpoint}` );
+      });
     }
   }
 ];


### PR DESCRIPTION
when uri conflict, `gateway-island` publish `SystemEndpointConflict` Event.

when this event is received, The warning is output.
<hr> 

uri가 충돌날 경우 gateway-island로부터 `SystemEndpointConflict` Event를 받습니다.

이 이벤트를 받을 경우 warning을 출력합니다.