### PR TITLE
fix: purge channels and reset idleChannelLength.

### DIFF
--- a/src/services/amqp-channel-pool-service.ts
+++ b/src/services/amqp-channel-pool-service.ts
@@ -54,6 +54,7 @@ export class AmqpChannelPoolService {
 
   async purge(): Promise<void> {
     this.idleChannels = [];
+    this.idleChannelLength = 0;
     return this.connection && this.connection.close();
   }
 


### PR DESCRIPTION
fix: construct amqp pool service object for every unittest

fix: more strict unit test pass condition