### PR TITLE
Fix can not catch error mongo

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "build": "gulp build",
     "watch": "gulp build && gulp watch",
     "clean": "gulp clean",
-    "test": "DEBUG=* ISLAND_LOGGER_LEVEL=crit gulp",
+    "test": "DEBUG=* ISLAND_USE_DEV_MODE=true ISLAND_LOGGER_LEVEL=crit gulp",
     "coverage": "gulp coverage"
   },
   "bin": {

--- a/src/adapters/impl/mongoose-adapter.ts
+++ b/src/adapters/impl/mongoose-adapter.ts
@@ -25,25 +25,24 @@ export default class MongooseAdapter extends AbstractAdapter<mongoose.Connection
    * @override
    */
   public initialize() {
-    return new Promise<void>((resolve, reject) => {
+    return new Promise<void>(async (resolve, reject) => {
       if (!this.options) throw new FatalError(ISLAND.FATAL.F0025_MISSING_ADAPTER_OPTIONS);
       // Mongoose buffers all the commands until it's connected to the database.
       // But make sure to the case of using a external mongodb connector
       const uri = this.options.uri;
       const connectionOptions = this.options.connectionOptions;
-      this.dnsLookup(uri).then(address => {
-        logger.info(`connecting to mongo ${address} with ${util.inspect(connectionOptions, { colors: true })}`);
-        const connection = mongoose.createConnection(address, connectionOptions);
-        connection.once('open', () => {
-          logger.info(`connected to mongo ${address} with ${util.inspect(connectionOptions, { colors: true })}`);
-          this._adaptee = connection;
-          connection.removeAllListeners();
-          resolve();
-        });
-        connection.once('error', err => {
-          logger.info(`connection error on mongo ${address} with ${util.inspect(connectionOptions, { colors: true })}`);
-          reject(err);
-        });
+      const address = await this.dnsLookup(uri);
+      logger.info(`connecting to mongo ${address} with ${util.inspect(connectionOptions, { colors: true })}`);
+      const connection = mongoose.createConnection(address, connectionOptions);
+      connection.once('open', () => {
+        logger.info(`connected to mongo ${address} with ${util.inspect(connectionOptions, { colors: true })}`);
+        this._adaptee = connection;
+        connection.removeAllListeners();
+        resolve();
+      });
+      connection.once('error', err => {
+        logger.info(`connection error on mongo ${address} with ${util.inspect(connectionOptions, { colors: true })}`);
+        reject(err);
       });
     });
   }

--- a/src/adapters/impl/mongoose-adapter.ts
+++ b/src/adapters/impl/mongoose-adapter.ts
@@ -24,16 +24,16 @@ export default class MongooseAdapter extends AbstractAdapter<mongoose.Connection
    * @returns {Promise<void>}
    * @override
    */
-  public initialize() {
-    return new Promise<void>(async (resolve, reject) => {
-      if (!this.options) throw new FatalError(ISLAND.FATAL.F0025_MISSING_ADAPTER_OPTIONS);
-      // Mongoose buffers all the commands until it's connected to the database.
-      // But make sure to the case of using a external mongodb connector
-      const uri = this.options.uri;
-      const connectionOptions = this.options.connectionOptions;
-      const address = await this.dnsLookup(uri);
-      logger.info(`connecting to mongo ${address} with ${util.inspect(connectionOptions, { colors: true })}`);
-      const connection = mongoose.createConnection(address, connectionOptions);
+  public async initialize() {
+    if (!this.options) throw new FatalError(ISLAND.FATAL.F0025_MISSING_ADAPTER_OPTIONS);
+    // Mongoose buffers all the commands until it's connected to the database.
+    // But make sure to the case of using a external mongodb connector
+    const uri = this.options.uri;
+    const connectionOptions = this.options.connectionOptions;
+    const address = await this.dnsLookup(uri);
+    logger.info(`connecting to mongo ${address} with ${util.inspect(connectionOptions, { colors: true })}`);
+    const connection = mongoose.createConnection(address, connectionOptions);
+    return new Promise<void>((resolve, reject) => {
       connection.once('open', () => {
         logger.info(`connected to mongo ${address} with ${util.inspect(connectionOptions, { colors: true })}`);
         this._adaptee = connection;

--- a/src/utils/environments.ts
+++ b/src/utils/environments.ts
@@ -166,6 +166,9 @@ export class IslandEnvironments {
   // deprecated
   @env()
   public ISLAND_FLOWMODE_DELAY: number = 0;
+  @env()
+  public ISLAND_MAX_INITIALIZATION_TIME: string = '1m';
+  public ISLAND_MAX_INITIALIZATION_TIME_MS: number = 0;
 
   // @env()
   // public ISLAND_IGNORE_EVENT_LOG: string = '';
@@ -192,6 +195,8 @@ export class IslandEnvironments {
     this.ISLAND_FLOWMODE_DELAY = this.ISLAND_FLOWMODE_DELAY === 0
                                  ? ms(this.ISLAND_FLOWMODE_DELAY_TIME)
                                  : this.ISLAND_FLOWMODE_DELAY;
+    this.ISLAND_MAX_INITIALIZATION_TIME_MS = ms(this.ISLAND_MAX_INITIALIZATION_TIME);
+
     LoadEnv(this);
   }
 


### PR DESCRIPTION
Bug Fix context
* Fixed that promise could not be caught if an error occurred in dns.lookup
* Added `adapter initilize timeout` that merged already in master branch