### PR TITLE
fix: typo environment

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "island",
-  "version": "3.6.2",
+  "version": "3.6.3",
   "description": "A package suite for building microservice using TypeScript.",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/src/utils/environments.ts
+++ b/src/utils/environments.ts
@@ -181,7 +181,7 @@ export class IslandEnvironments {
                                       ? ms(this.ISLAND_RPC_EXEC_TIMEOUT)
                                       : this.ISLAND_RPC_EXEC_TIMEOUT_MS;
     this.ISLAND_RPC_WAIT_TIMEOUT_MS = this.ISLAND_RPC_WAIT_TIMEOUT_MS === 0
-                                      ? ms(this.ISLAND_RPC_EXEC_TIMEOUT)
+                                      ? ms(this.ISLAND_RPC_WAIT_TIMEOUT)
                                       : this.ISLAND_RPC_WAIT_TIMEOUT_MS;
     this.ISLAND_SERVICE_LOAD_TIME_MS = this.ISLAND_SERVICE_LOAD_TIME_MS === 0
                                        ? ms(this.ISLAND_SERVICE_LOAD_TIME)


### PR DESCRIPTION
major environment is wrong

`ISLAND_RPC_EXEC_TIMEOUT` is the time to wait for the RPC in release-3.6

Due to typo this time has been shortened from `60s` to `25s`.

This issue causes the following problems:
- Due to the Queue setting, it can not be used with the lower version.
- RPC Timeout is shorter.
