### PR TITLE
feat: new event options, guaranteeArrivalTime

### DIFF
--- a/src/controllers/event-decorator.ts
+++ b/src/controllers/event-decorator.ts
@@ -1,6 +1,5 @@
 import * as Bluebird from 'bluebird';
 import { Event } from 'island-types';
-
 import { EventHandler, SubscriptionOptions } from '../services/event-subscriber';
 import { EventSubscription } from '../utils/event';
 import AbstractController from './abstract-controller';
@@ -51,7 +50,7 @@ export function subscribeEvent<T extends Event<U>, U>(eventClass: new (args: U) 
 }
 
 export function subscribePattern(pattern: string, options?: SubscriptionOptions) {
-  return (target: any, propertyKey: string, desc: PropertyDescriptor) => {
+  return (target: any, _key: string, desc: PropertyDescriptor) => {
     pattern = pattern.trim();
     const constructor = target.constructor as Function & PatternSubscriptionContainer;
     constructor._patternSubscriptions = constructor._patternSubscriptions || [];

--- a/src/services/event-service.ts
+++ b/src/services/event-service.ts
@@ -267,7 +267,7 @@ export class EventService {
           logger.debug(`subscribe event : ${msg.fields.routingKey}`, content, msg.properties.headers);
         }
         if (subscriber.getOptions().guaranteeArrivalTime &&
-            Date.now() - (msg.properties.timestamp || Date.now()) > Environments.ISLAND_ALLOWED_ARRIVAL_TIME_MS) {
+            Date.now() - (msg.properties.timestamp || Date.now()) > Environments.ISLAND_EVENT_ALLOWED_ARRIVAL_TIME_MS) {
           logger.info(`ignore event arrived late : ${msg.fields.routingKey}`);
           return Bluebird.resolve();
         }

--- a/src/services/event-service.ts
+++ b/src/services/event-service.ts
@@ -123,15 +123,15 @@ export class EventService {
 
   subscribeEvent<T extends Event<U>, U>(eventClass: new (args: U) => T,
                                         handler: EventHandler<T>,
-                                        options?: SubscriptionOptions): Promise<void> {
-    return Promise.resolve(Bluebird.try(() => new EventSubscriber(handler, eventClass, options || {}))
+                                        options: SubscriptionOptions = {}): Promise<void> {
+    return Promise.resolve(Bluebird.try(() => new EventSubscriber(handler, eventClass, options))
       .then(subscriber => this.subscribe(subscriber)));
   }
 
   subscribePattern(pattern: string,
                    handler: EventHandler<Event<any>>,
-                   options?: SubscriptionOptions): Promise<void> {
-    return Promise.resolve(Bluebird.try(() => new PatternSubscriber(handler, pattern, options || {}))
+                   options: SubscriptionOptions = {}): Promise<void> {
+    return Promise.resolve(Bluebird.try(() => new PatternSubscriber(handler, pattern, options))
       .then(subscriber => this.subscribe(subscriber)));
   }
 

--- a/src/spec/event-service.spec.ts
+++ b/src/spec/event-service.spec.ts
@@ -238,7 +238,7 @@ describe('Event-hook', () => {
       fail();
     }, { guaranteeArrivalTime: true });
     const event = new TestEvent('bbb');
-    event.publishedAt = new Date(Date.now() - Environments.ISLAND_ALLOWED_ARRIVAL_TIME_MS - 100);
+    event.publishedAt = new Date(Date.now() - Environments.ISLAND_EVENT_ALLOWED_ARRIVAL_TIME_MS - 100);
     await eventService.publishEvent(event);
     await eventService.sigInfo();
   }));
@@ -251,7 +251,7 @@ describe('Event-hook', () => {
       expect(event.args).toBe('xbbb');
     }, { guaranteeArrivalTime: false });
     const event = new TestEvent('bbb');
-    event.publishedAt = new Date(Date.now() - Environments.ISLAND_ALLOWED_ARRIVAL_TIME_MS - 100);
+    event.publishedAt = new Date(Date.now() - Environments.ISLAND_EVENT_ALLOWED_ARRIVAL_TIME_MS - 100);
     await eventService.publishEvent(event);
     await eventService.sigInfo();
   }));

--- a/src/spec/event-service.spec.ts
+++ b/src/spec/event-service.spec.ts
@@ -2,7 +2,7 @@ import { BaseEvent, DebugEvent } from 'island-types';
 
 import { AmqpChannelPoolService } from '../services/amqp-channel-pool-service';
 import { EventHookType, EventService } from '../services/event-service';
-import { PatternSubscriber } from '../services/event-subscriber';
+import { EventSubscriber, PatternSubscriber } from '../services/event-subscriber';
 import { Environments } from '../utils/environments';
 import { jasmineAsyncAdapter as spec } from '../utils/jasmine-async-support';
 
@@ -121,14 +121,14 @@ describe('PatternSubscriber', () => {
   describe('isRoutingKeyMatched', () => {
     it('should test a pattern with plain text', () => {
       const s = new PatternSubscriber(event => {
-      }, 'aaa.aaa.aaa');
+      }, 'aaa.aaa.aaa', {});
       expect(s.isRoutingKeyMatched('aaa.aaa.aaa')).toBeTruthy();
       expect(s.isRoutingKeyMatched('aaa.aaa.bbb')).toBeFalsy();
     });
 
     it('should test a pattern using *', () => {
       const s = new PatternSubscriber(event => {
-      }, 'aaa.aaa.*');
+      }, 'aaa.aaa.*', {});
       expect(s.isRoutingKeyMatched('aaa.aaa.aaa')).toBeTruthy();
       expect(s.isRoutingKeyMatched('aaa.aaa.bbb')).toBeTruthy();
       expect(s.isRoutingKeyMatched('aaa.bbb.aaa')).toBeFalsy();
@@ -137,13 +137,45 @@ describe('PatternSubscriber', () => {
 
     it('should test a pattern using #', () => {
       const s = new PatternSubscriber(event => {
-      }, 'aaa.#');
+      }, 'aaa.#', {});
       expect(s.isRoutingKeyMatched('aaa.aaa.aaa')).toBeTruthy();
       expect(s.isRoutingKeyMatched('aaa.bbb.bbb')).toBeTruthy();
       expect(s.isRoutingKeyMatched('aaa.bbb')).toBeTruthy();
       expect(s.isRoutingKeyMatched('aaa')).toBeFalsy();
       expect(s.isRoutingKeyMatched('ccc.aaa.bbb')).toBeFalsy();
     });
+  });
+
+  it('should options saved in PatternSubscriber', () => {
+    const e1 = new PatternSubscriber(_event => {}, 'aaa.#',
+      { everyNodeListen: true, guaranteeArrivalTime: true });
+    expect(e1.getOptions().everyNodeListen).toBeTruthy();
+    expect(e1.getOptions().guaranteeArrivalTime).toBeTruthy();
+    const e2 = new PatternSubscriber(_event => {}, 'aaa.#',
+      { everyNodeListen: true, guaranteeArrivalTime: false });
+    expect(e2.getOptions().everyNodeListen).toBeTruthy();
+    expect(e2.getOptions().guaranteeArrivalTime).not.toBeTruthy();
+    const e3 = new PatternSubscriber(_event => {}, 'aaa.#',
+      { everyNodeListen: false, guaranteeArrivalTime: true });
+    expect(e3.getOptions().everyNodeListen).not.toBeTruthy();
+    expect(e3.getOptions().guaranteeArrivalTime).toBeTruthy();
+  });
+});
+
+describe('EventSubscriber', () => {
+  it('should options saved in EventSubscriber', () => {
+    const e1 = new EventSubscriber(_event => {}, TestEvent,
+      { everyNodeListen: true, guaranteeArrivalTime: true });
+    expect(e1.getOptions().everyNodeListen).toBeTruthy();
+    expect(e1.getOptions().guaranteeArrivalTime).toBeTruthy();
+    const e2 = new EventSubscriber(_event => {}, TestEvent,
+      { everyNodeListen: true, guaranteeArrivalTime: false });
+    expect(e2.getOptions().everyNodeListen).toBeTruthy();
+    expect(e2.getOptions().guaranteeArrivalTime).not.toBeTruthy();
+    const e3 = new EventSubscriber(_event => {}, TestEvent,
+      { everyNodeListen: false, guaranteeArrivalTime: true });
+    expect(e3.getOptions().everyNodeListen).not.toBeTruthy();
+    expect(e3.getOptions().guaranteeArrivalTime).toBeTruthy();
   });
 });
 
@@ -195,6 +227,32 @@ describe('Event-hook', () => {
       expect(event.args).toBe('xbbb');
     });
     await eventService.publishEvent(new TestEvent('bbb'));
+    await eventService.sigInfo();
+  }));
+
+  it('should Old event are ignored when the guaranteeArrivalTime option is used', spec(async () => {
+    eventService.registerHook(EventHookType.EVENT, p => {
+      return Promise.resolve('x' + p);
+    });
+    await eventService.subscribeEvent(TestEvent, (_event: TestEvent) => {
+      fail();
+    }, { guaranteeArrivalTime: true });
+    const event = new TestEvent('bbb');
+    event.publishedAt = new Date(Date.now() - Environments.ISLAND_ALLOWED_ARRIVAL_TIME_MS - 100);
+    await eventService.publishEvent(event);
+    await eventService.sigInfo();
+  }));
+
+  it('should Old event are not ignored when the guaranteeArrivalTime option is false', spec(async () => {
+    eventService.registerHook(EventHookType.EVENT, p => {
+      return Promise.resolve('x' + p);
+    });
+    await eventService.subscribeEvent(TestEvent, (event: TestEvent) => {
+      expect(event.args).toBe('xbbb');
+    }, { guaranteeArrivalTime: false });
+    const event = new TestEvent('bbb');
+    event.publishedAt = new Date(Date.now() - Environments.ISLAND_ALLOWED_ARRIVAL_TIME_MS - 100);
+    await eventService.publishEvent(event);
     await eventService.sigInfo();
   }));
 });

--- a/src/utils/environments.ts
+++ b/src/utils/environments.ts
@@ -169,8 +169,8 @@ export class IslandEnvironments {
   public VERSION: string = 'unknown';
 
   @env()
-  public ISLAND_ALLOWED_ARRIVAL_TIME: string = '2s';
-  public ISLAND_ALLOWED_ARRIVAL_TIME_MS: number = 0;
+  public ISLAND_EVENT_ALLOWED_ARRIVAL_TIME: string = '2s';
+  public ISLAND_EVENT_ALLOWED_ARRIVAL_TIME_MS: number = 0;
   // @env()
   // public ISLAND_IGNORE_EVENT_LOG: string = '';
 
@@ -194,7 +194,7 @@ export class IslandEnvironments {
     this.ISLAND_RPC_REPLY_MARGIN_TIME_MS = ms(this.ISLAND_RPC_REPLY_MARGIN_TIME);
     this.ISLAND_MAX_INITIALIZATION_TIME_MS = ms(this.ISLAND_MAX_INITIALIZATION_TIME);
 
-    this.ISLAND_ALLOWED_ARRIVAL_TIME_MS = ms(this.ISLAND_ALLOWED_ARRIVAL_TIME);
+    this.ISLAND_EVENT_ALLOWED_ARRIVAL_TIME_MS = ms(this.ISLAND_EVENT_ALLOWED_ARRIVAL_TIME);
 
     this.setIslandInfoFromPackageJson();
     LoadEnv(this);

--- a/src/utils/environments.ts
+++ b/src/utils/environments.ts
@@ -168,6 +168,9 @@ export class IslandEnvironments {
 
   public VERSION: string = 'unknown';
 
+  @env()
+  public ISLAND_ALLOWED_ARRIVAL_TIME: string = '2s';
+  public ISLAND_ALLOWED_ARRIVAL_TIME_MS: number = 0;
   // @env()
   // public ISLAND_IGNORE_EVENT_LOG: string = '';
 
@@ -190,6 +193,8 @@ export class IslandEnvironments {
                                  : this.ISLAND_FLOWMODE_DELAY;
     this.ISLAND_RPC_REPLY_MARGIN_TIME_MS = ms(this.ISLAND_RPC_REPLY_MARGIN_TIME);
     this.ISLAND_MAX_INITIALIZATION_TIME_MS = ms(this.ISLAND_MAX_INITIALIZATION_TIME);
+
+    this.ISLAND_ALLOWED_ARRIVAL_TIME_MS = ms(this.ISLAND_ALLOWED_ARRIVAL_TIME);
 
     this.setIslandInfoFromPackageJson();
     LoadEnv(this);


### PR DESCRIPTION
Add the event Service option.

`guaranteeArrivalTime` Setting ignores this event if the Event arrives later than `Environments.AllowedArrivalTime(Default 2 Sec)`.

It is used as follows.
```
@subscribePattern('cron.s.#.00', { guaranteeArrivalTime: true })
```
<hr>
이벤트 서비스에 `guaranteeArrivalTime` 옵션을 추가합니다.
이 옵션이 사용될 경우 이벤트가 `Environments.AllowedArrivalTime(기본값 2초)`보다 늦게 도착할 경우 실행되지 않고 무시됩니다.
