### PR TITLE
fix:channel is not removed from idleChannels when channel closed

### DIFF
--- a/src/services/amqp-channel-pool-service.ts
+++ b/src/services/amqp-channel-pool-service.ts
@@ -117,7 +117,7 @@ export class AmqpChannelPoolService {
       })
       .on('close', async () => {
         await Promise.all(_.map(this.idleChannels, async obj => {
-          obj.then( value => {
+          return obj.then( value => {
             if ( (value as any).ch === (channel as any).ch) {
               (obj as any).terminate = true;
             }


### PR DESCRIPTION
# AS-IS
When channel closed, channel try to remove itself from idleChannels. But it would not removed because channel remove statement could be run before marking terminate is finished due to missing `return` statement before `obj.then( ... )`. It returns void promise and not wait obj.then.


```
private async setChannelEventHandler(channel: amqp.Channel) {
    channel
      .on('error', err => {...})
      .on('close', async () => {
        await Promise.all(_.map(this.idleChannels, async obj => {
          obj.then( value => {
            if ( (value as any).ch === (channel as any).ch) {
              (obj as any).terminate = true;
            }
          });
        }));
        _.remove(this.idleChannels, obj => { 
          return (obj as any).terminate;
        });
      });
  }
```

# TO-BE
resolve this by adding `return` statement before `obj.then(...)`.